### PR TITLE
Use 'Invalid value' wording for Literal and Enum validation errors

### DIFF
--- a/docs/supported-types.rst
+++ b/docs/supported-types.rst
@@ -1112,7 +1112,7 @@ doesn't match any valid member.
     >>> msgspec.json.decode(b'"grape"', type=Fruit)
     Traceback (most recent call last):
       File "<stdin>", line 1, in <module>
-    msgspec.ValidationError: Invalid enum value 'grape'
+    msgspec.ValidationError: Invalid value 'grape'
 
     >>> class JobState(enum.IntEnum):
     ...     CREATED = 0
@@ -1129,7 +1129,7 @@ doesn't match any valid member.
     >>> msgspec.json.decode(b'4', type=JobState)
     Traceback (most recent call last):
       File "<stdin>", line 1, in <module>
-    msgspec.ValidationError: Invalid enum value 4
+    msgspec.ValidationError: Invalid value 4
 
 If the enum type includes a ``_missing_`` method (`docs
 <https://docs.python.org/3/library/enum.html#enum.Enum._missing_>`__), this
@@ -1162,7 +1162,7 @@ this is supporting case-insensitive enums:
     >>> msgspec.json.decode(b'"grape"', type=Fruit)
     Traceback (most recent call last):
       File "<stdin>", line 1, in <module>
-    msgspec.ValidationError: Invalid enum value 'grape'
+    msgspec.ValidationError: Invalid value 'grape'
 
 ``Literal``
 -----------
@@ -1196,7 +1196,7 @@ values, or doesn't match any of their component types.
     >>> msgspec.json.decode(b'4', type=Literal[1, 2, 3])
     Traceback (most recent call last):
       File "<stdin>", line 1, in <module>
-    msgspec.ValidationError: Invalid enum value 4
+    msgspec.ValidationError: Invalid value 4
 
     >>> msgspec.json.decode(b'"bad"', type=Literal[1, 2, 3])
     Traceback (most recent call last):

--- a/src/msgspec/_core.c
+++ b/src/msgspec/_core.c
@@ -884,7 +884,10 @@ _Lookup_OnMissing(Lookup *lookup, PyObject *val, PathNode *path) {
     }
     PyObject *suffix = PathNode_ErrSuffix(path);
     if (suffix != NULL) {
-        PyErr_Format(mod->ValidationError, "Invalid enum value %R%U", val, suffix);
+        const char *format = (lookup->cls != NULL)
+            ? "Invalid enum value %R%U"
+            : "Invalid value %R%U";
+        PyErr_Format(mod->ValidationError, format, val, suffix);
         Py_DECREF(suffix);
     }
 
@@ -15366,7 +15369,7 @@ mpack_decode_bool(DecoderState *self, PyObject *val, TypeNode *type, PathNode *p
         return Py_False;
     }
     if (type->types & (MS_TYPE_BOOLLITERAL_TRUE | MS_TYPE_BOOLLITERAL_FALSE)) {
-        ms_raise_validation_error(path, "Invalid enum value %R%U", val);
+        ms_raise_validation_error(path, "Invalid value %R%U", val);
         return NULL;
     }
     return ms_validation_error("bool", type, path);
@@ -16999,7 +17002,7 @@ json_decode_true(JSONDecoderState *self, TypeNode *type, PathNode *path) {
         return Py_True;
     }
     if (type->types & MS_TYPE_BOOLLITERAL_FALSE) {
-        ms_raise_validation_error(path, "Invalid enum value %R%U", Py_True);
+        ms_raise_validation_error(path, "Invalid value %R%U", Py_True);
         return NULL;
     }
     return ms_validation_error("bool", type, path);
@@ -17024,7 +17027,7 @@ json_decode_false(JSONDecoderState *self, TypeNode *type, PathNode *path) {
         return Py_False;
     }
     if (type->types & MS_TYPE_BOOLLITERAL_TRUE) {
-        ms_raise_validation_error(path, "Invalid enum value %R%U", Py_False);
+        ms_raise_validation_error(path, "Invalid value %R%U", Py_False);
         return NULL;
     }
     return ms_validation_error("bool", type, path);
@@ -20683,7 +20686,7 @@ convert_bool(
         return Py_False;
     }
     if (type->types & (MS_TYPE_BOOLLITERAL_TRUE | MS_TYPE_BOOLLITERAL_FALSE)) {
-        ms_raise_validation_error(path, "Invalid enum value %R%U", obj);
+        ms_raise_validation_error(path, "Invalid value %R%U", obj);
         return NULL;
     }
     return ms_validation_error("bool", type, path);

--- a/src/msgspec/_core.c
+++ b/src/msgspec/_core.c
@@ -906,7 +906,7 @@ _Lookup_OnMissing(Lookup *lookup, PyObject *val, PathNode *path) {
     }
     PyObject *suffix = PathNode_ErrSuffix(path);
     if (suffix != NULL) {
-        PyErr_Format(mod->ValidationError, "Invalid enum value %R%U", val, suffix);
+        PyErr_Format(mod->ValidationError, "Invalid value %R%U", val, suffix);
         Py_DECREF(suffix);
     }
 
@@ -15594,7 +15594,7 @@ mpack_decode_bool(DecoderState *self, PyObject *val, TypeNode *type, PathNode *p
         return Py_False;
     }
     if (type->types & (MS_TYPE_BOOLLITERAL_TRUE | MS_TYPE_BOOLLITERAL_FALSE)) {
-        ms_raise_validation_error(path, "Invalid enum value %R%U", val);
+        ms_raise_validation_error(path, "Invalid value %R%U", val);
         return NULL;
     }
     return ms_validation_error("bool", type, path);
@@ -17249,7 +17249,7 @@ json_decode_true(JSONDecoderState *self, TypeNode *type, PathNode *path) {
         return Py_True;
     }
     if (type->types & MS_TYPE_BOOLLITERAL_FALSE) {
-        ms_raise_validation_error(path, "Invalid enum value %R%U", Py_True);
+        ms_raise_validation_error(path, "Invalid value %R%U", Py_True);
         return NULL;
     }
     return ms_validation_error("bool", type, path);
@@ -17274,7 +17274,7 @@ json_decode_false(JSONDecoderState *self, TypeNode *type, PathNode *path) {
         return Py_False;
     }
     if (type->types & MS_TYPE_BOOLLITERAL_TRUE) {
-        ms_raise_validation_error(path, "Invalid enum value %R%U", Py_False);
+        ms_raise_validation_error(path, "Invalid value %R%U", Py_False);
         return NULL;
     }
     return ms_validation_error("bool", type, path);
@@ -20988,7 +20988,7 @@ convert_bool(
         return Py_False;
     }
     if (type->types & (MS_TYPE_BOOLLITERAL_TRUE | MS_TYPE_BOOLLITERAL_FALSE)) {
-        ms_raise_validation_error(path, "Invalid enum value %R%U", obj);
+        ms_raise_validation_error(path, "Invalid value %R%U", obj);
         return NULL;
     }
     return ms_validation_error("bool", type, path);

--- a/tests/unit/test_common.py
+++ b/tests/unit/test_common.py
@@ -903,10 +903,10 @@ class TestLiterals:
         for val in [-1, -2, -3, "apple", "banana"]:
             assert dec.decode(msgspec.msgpack.encode(val)) == val
 
-        with pytest.raises(ValidationError, match="Invalid enum value 4"):
+        with pytest.raises(ValidationError, match="Invalid value 4"):
             dec.decode(msgspec.msgpack.encode(4))
 
-        with pytest.raises(ValidationError, match="Invalid enum value 'carrot'"):
+        with pytest.raises(ValidationError, match="Invalid value 'carrot'"):
             dec.decode(msgspec.msgpack.encode("carrot"))
 
     def test_nested_literals(self):
@@ -921,10 +921,10 @@ class TestLiterals:
         for val in [-1, -2, -3, "apple", "banana"]:
             assert dec.decode(msgspec.msgpack.encode(val)) == val
 
-        with pytest.raises(ValidationError, match="Invalid enum value 4"):
+        with pytest.raises(ValidationError, match="Invalid value 4"):
             dec.decode(msgspec.msgpack.encode(4))
 
-        with pytest.raises(ValidationError, match="Invalid enum value 'carrot'"):
+        with pytest.raises(ValidationError, match="Invalid value 'carrot'"):
             dec.decode(msgspec.msgpack.encode("carrot"))
 
     @pytest.mark.parametrize(
@@ -947,7 +947,7 @@ class TestLiterals:
 
     def test_literal_bool_error_message(self):
         dec = msgspec.msgpack.Decoder(Literal[True])
-        with pytest.raises(ValidationError, match="Invalid enum value False"):
+        with pytest.raises(ValidationError, match="Invalid value False"):
             dec.decode(msgspec.msgpack.encode(False))
 
     def test_mix_bool_and_bool_literal(self):
@@ -4451,7 +4451,7 @@ class TestLax:
 
         assert roundtrip("1") == 1
         assert roundtrip("-2") == -2
-        with pytest.raises(ValidationError, match="Invalid enum value 3"):
+        with pytest.raises(ValidationError, match="Invalid value 3"):
             roundtrip("3")
         with pytest.raises(ValidationError, match="Expected `int`, got `str`"):
             roundtrip("A")

--- a/tests/unit/test_common.py
+++ b/tests/unit/test_common.py
@@ -445,7 +445,7 @@ class TestIntEnum:
         assert dec.decode(proto.encode(1)) is Test.A
         assert dec.decode(proto.encode(2)) is Test.B
 
-        with pytest.raises(ValidationError, match="Invalid enum value 3"):
+        with pytest.raises(ValidationError, match="Invalid value 3"):
             dec.decode(proto.encode(3))
 
     def test_decode_nested(self, proto):
@@ -456,9 +456,7 @@ class TestIntEnum:
 
         dec.decode(proto.encode({"fruit": 1})) == Test(FruitInt.APPLE)
 
-        with pytest.raises(
-            ValidationError, match=r"Invalid enum value 3 - at `\$.fruit`"
-        ):
+        with pytest.raises(ValidationError, match=r"Invalid value 3 - at `\$.fruit`"):
             dec.decode(proto.encode({"fruit": 3}))
 
     def test_intenum_missing(self, proto):
@@ -485,9 +483,9 @@ class TestIntEnum:
         assert roundtrip(1) is Ex.A
         assert roundtrip(3) is Ex.A
         assert roundtrip(-4) is Ex.B
-        with pytest.raises(ValidationError, match="Invalid enum value 5"):
+        with pytest.raises(ValidationError, match="Invalid value 5"):
             roundtrip(5)
-        with pytest.raises(ValidationError, match="Invalid enum value 6"):
+        with pytest.raises(ValidationError, match="Invalid value 6"):
             roundtrip(6)
 
     def test_intflag(self, proto):
@@ -707,7 +705,7 @@ class TestEnum:
         assert dec.decode(proto.encode("apple")) is Test.A
         assert dec.decode(proto.encode("banana")) is Test.B
 
-        with pytest.raises(ValidationError, match="Invalid enum value 'cherry'"):
+        with pytest.raises(ValidationError, match="Invalid value 'cherry'"):
             dec.decode(proto.encode("cherry"))
 
     def test_decode_nested(self, proto):
@@ -720,7 +718,7 @@ class TestEnum:
 
         with pytest.raises(
             ValidationError,
-            match=r"Invalid enum value 'cherry' - at `\$.fruit`",
+            match=r"Invalid value 'cherry' - at `\$.fruit`",
         ):
             dec.decode(proto.encode({"fruit": "cherry"}))
 
@@ -855,9 +853,9 @@ class TestEnum:
         assert roundtrip("a") is Ex.A
         assert roundtrip("return-A") is Ex.A
         assert roundtrip("return-B") is Ex.B
-        with pytest.raises(ValidationError, match="Invalid enum value 'error'"):
+        with pytest.raises(ValidationError, match="Invalid value 'error'"):
             roundtrip("error")
-        with pytest.raises(ValidationError, match="Invalid enum value 'other'"):
+        with pytest.raises(ValidationError, match="Invalid value 'other'"):
             roundtrip("other")
 
 
@@ -963,10 +961,10 @@ class TestLiterals:
         for val in [-1, -2, -3, "apple", "banana"]:
             assert dec.decode(msgspec.msgpack.encode(val)) == val
 
-        with pytest.raises(ValidationError, match="Invalid enum value 4"):
+        with pytest.raises(ValidationError, match="Invalid value 4"):
             dec.decode(msgspec.msgpack.encode(4))
 
-        with pytest.raises(ValidationError, match="Invalid enum value 'carrot'"):
+        with pytest.raises(ValidationError, match="Invalid value 'carrot'"):
             dec.decode(msgspec.msgpack.encode("carrot"))
 
     def test_nested_literals(self):
@@ -981,10 +979,10 @@ class TestLiterals:
         for val in [-1, -2, -3, "apple", "banana"]:
             assert dec.decode(msgspec.msgpack.encode(val)) == val
 
-        with pytest.raises(ValidationError, match="Invalid enum value 4"):
+        with pytest.raises(ValidationError, match="Invalid value 4"):
             dec.decode(msgspec.msgpack.encode(4))
 
-        with pytest.raises(ValidationError, match="Invalid enum value 'carrot'"):
+        with pytest.raises(ValidationError, match="Invalid value 'carrot'"):
             dec.decode(msgspec.msgpack.encode("carrot"))
 
     @pytest.mark.parametrize(
@@ -1007,7 +1005,7 @@ class TestLiterals:
 
     def test_literal_bool_error_message(self):
         dec = msgspec.msgpack.Decoder(Literal[True])
-        with pytest.raises(ValidationError, match="Invalid enum value False"):
+        with pytest.raises(ValidationError, match="Invalid value False"):
             dec.decode(msgspec.msgpack.encode(False))
 
     def test_mix_bool_and_bool_literal(self):
@@ -5398,7 +5396,7 @@ class TestLax:
 
         assert roundtrip("1") is Ex.x
         assert roundtrip("-2") is Ex.y
-        with pytest.raises(ValidationError, match="Invalid enum value 3"):
+        with pytest.raises(ValidationError, match="Invalid value 3"):
             roundtrip("3")
         with pytest.raises(ValidationError, match="Expected `int`, got `str`"):
             roundtrip("A")
@@ -5411,7 +5409,7 @@ class TestLax:
 
         assert roundtrip("1") == 1
         assert roundtrip("-2") == -2
-        with pytest.raises(ValidationError, match="Invalid enum value 3"):
+        with pytest.raises(ValidationError, match="Invalid value 3"):
             roundtrip("3")
         with pytest.raises(ValidationError, match="Expected `int`, got `str`"):
             roundtrip("A")

--- a/tests/unit/test_convert.py
+++ b/tests/unit/test_convert.py
@@ -905,7 +905,7 @@ class TestLiteral:
         typ = Literal["A", "B"]
         assert convert("A", typ) == "A"
         assert convert("B", typ) == "B"
-        with pytest.raises(ValidationError, match="Invalid enum value 'C'"):
+        with pytest.raises(ValidationError, match="Invalid value 'C'"):
             convert("C", typ)
         with pytest.raises(ValidationError, match="Expected `str`, got `int`"):
             convert(1, typ)
@@ -914,9 +914,9 @@ class TestLiteral:
         typ = Literal[1, -2]
         assert convert(1, typ) == 1
         assert convert(-2, typ) == -2
-        with pytest.raises(ValidationError, match="Invalid enum value 3"):
+        with pytest.raises(ValidationError, match="Invalid value 3"):
             convert(3, typ)
-        with pytest.raises(ValidationError, match="Invalid enum value -3"):
+        with pytest.raises(ValidationError, match="Invalid value -3"):
             convert(-3, typ)
         with pytest.raises(ValidationError, match="Expected `int`, got `str`"):
             convert("A", typ)
@@ -2366,7 +2366,7 @@ class TestLax:
         typ = Literal[1, -2]
         assert convert("1", typ, strict=False) == 1
         assert convert("-2", typ, strict=False) == -2
-        with pytest.raises(ValidationError, match="Invalid enum value 3"):
+        with pytest.raises(ValidationError, match="Invalid value 3"):
             convert("3", typ, strict=False)
         with pytest.raises(ValidationError, match="Expected `int`, got `str`"):
             convert("A", typ, strict=False)

--- a/tests/unit/test_convert.py
+++ b/tests/unit/test_convert.py
@@ -781,7 +781,7 @@ class TestEnum:
         assert convert(Ex.x, Ex) is Ex.x
         assert convert("A", Ex) is Ex.x
         assert convert("B", Ex) is Ex.y
-        with pytest.raises(ValidationError, match="Invalid enum value 'C'"):
+        with pytest.raises(ValidationError, match="Invalid value 'C'"):
             convert("C", Ex)
         with pytest.raises(ValidationError, match="Expected `str`, got `int`"):
             convert(1, Ex)
@@ -802,10 +802,10 @@ class TestEnum:
         assert convert(2, Ex) is Ex.y
         assert convert(Ex2.a, Ex) is Ex.x
 
-        with pytest.raises(ValidationError, match="Invalid enum value 3"):
+        with pytest.raises(ValidationError, match="Invalid value 3"):
             convert(3, Ex)
 
-        with pytest.raises(ValidationError, match="Invalid enum value 3"):
+        with pytest.raises(ValidationError, match="Invalid value 3"):
             convert(Ex2.b, Ex)
 
         with pytest.raises(ValidationError, match="Expected `int`, got `str`"):
@@ -828,10 +828,10 @@ class TestEnum:
         assert convert("B", Ex) is Ex.y
         assert convert(Ex2.a, Ex) is Ex.x
 
-        with pytest.raises(ValidationError, match="Invalid enum value 'C'"):
+        with pytest.raises(ValidationError, match="Invalid value 'C'"):
             convert("C", Ex)
 
-        with pytest.raises(ValidationError, match="Invalid enum value 'C'"):
+        with pytest.raises(ValidationError, match="Invalid value 'C'"):
             convert(Ex2.b, Ex)
 
         with pytest.raises(ValidationError, match="Expected `str`, got `int`"):
@@ -869,9 +869,9 @@ class TestEnum:
         assert msgspec.convert("a", Ex) is Ex.A
         assert msgspec.convert("return-A", Ex) is Ex.A
         assert msgspec.convert("return-B", Ex) is Ex.B
-        with pytest.raises(ValidationError, match="Invalid enum value 'error'"):
+        with pytest.raises(ValidationError, match="Invalid value 'error'"):
             msgspec.convert("error", Ex)
-        with pytest.raises(ValidationError, match="Invalid enum value 'other'"):
+        with pytest.raises(ValidationError, match="Invalid value 'other'"):
             msgspec.convert("other", Ex)
 
     def test_intenum_missing(self):
@@ -893,9 +893,9 @@ class TestEnum:
         assert msgspec.convert(1, Ex) is Ex.A
         assert msgspec.convert(3, Ex) is Ex.A
         assert msgspec.convert(-4, Ex) is Ex.B
-        with pytest.raises(ValidationError, match="Invalid enum value 5"):
+        with pytest.raises(ValidationError, match="Invalid value 5"):
             msgspec.convert(5, Ex)
-        with pytest.raises(ValidationError, match="Invalid enum value 6"):
+        with pytest.raises(ValidationError, match="Invalid value 6"):
             msgspec.convert(6, Ex)
 
     @pytest.mark.parametrize(
@@ -912,7 +912,7 @@ class TestEnum:
         assert convert(Test.A, Test) is Test.A
         assert convert("apple", Test) is Test.A
         assert convert("banana", Test) is Test.B
-        with pytest.raises(ValidationError, match="Invalid enum value 'ceeee'"):
+        with pytest.raises(ValidationError, match="Invalid value 'ceeee'"):
             convert("ceeee", Test)
         with pytest.raises(ValidationError, match="Expected `str`, got `int`"):
             convert(1, Test)
@@ -923,7 +923,7 @@ class TestLiteral:
         typ = Literal["A", "B"]
         assert convert("A", typ) == "A"
         assert convert("B", typ) == "B"
-        with pytest.raises(ValidationError, match="Invalid enum value 'C'"):
+        with pytest.raises(ValidationError, match="Invalid value 'C'"):
             convert("C", typ)
         with pytest.raises(ValidationError, match="Expected `str`, got `int`"):
             convert(1, typ)
@@ -932,9 +932,9 @@ class TestLiteral:
         typ = Literal[1, -2]
         assert convert(1, typ) == 1
         assert convert(-2, typ) == -2
-        with pytest.raises(ValidationError, match="Invalid enum value 3"):
+        with pytest.raises(ValidationError, match="Invalid value 3"):
             convert(3, typ)
-        with pytest.raises(ValidationError, match="Invalid enum value -3"):
+        with pytest.raises(ValidationError, match="Invalid value -3"):
             convert(-3, typ)
         with pytest.raises(ValidationError, match="Expected `int`, got `str`"):
             convert("A", typ)
@@ -944,9 +944,9 @@ class TestLiteral:
         assert convert(False, Literal[False]) is False
         assert convert(True, Literal[True, False]) is True
         assert convert(False, Literal[True, False]) is False
-        with pytest.raises(ValidationError, match="Invalid enum value False"):
+        with pytest.raises(ValidationError, match="Invalid value False"):
             convert(False, Literal[True])
-        with pytest.raises(ValidationError, match="Invalid enum value True"):
+        with pytest.raises(ValidationError, match="Invalid value True"):
             convert(True, Literal[False])
         with pytest.raises(ValidationError, match="Expected `bool`, got `str`"):
             convert("yes", Literal[True])
@@ -2528,7 +2528,7 @@ class TestLax:
 
         assert convert("1", Ex, strict=False) is Ex.x
         assert convert("-2", Ex, strict=False) is Ex.y
-        with pytest.raises(ValidationError, match="Invalid enum value 3"):
+        with pytest.raises(ValidationError, match="Invalid value 3"):
             convert("3", Ex, strict=False)
         with pytest.raises(ValidationError, match="Expected `int`, got `str`"):
             convert("A", Ex, strict=False)
@@ -2537,7 +2537,7 @@ class TestLax:
         typ = Literal[1, -2]
         assert convert("1", typ, strict=False) == 1
         assert convert("-2", typ, strict=False) == -2
-        with pytest.raises(ValidationError, match="Invalid enum value 3"):
+        with pytest.raises(ValidationError, match="Invalid value 3"):
             convert("3", typ, strict=False)
         with pytest.raises(ValidationError, match="Expected `int`, got `str`"):
             convert("A", typ, strict=False)

--- a/tests/unit/test_json.py
+++ b/tests/unit/test_json.py
@@ -1214,7 +1214,7 @@ class TestLiteral:
     def test_int_literal_errors(self):
         dec = msgspec.json.Decoder(Literal[1, 2, 3])
 
-        with pytest.raises(msgspec.ValidationError, match="Invalid enum value 4"):
+        with pytest.raises(msgspec.ValidationError, match="Invalid value 4"):
             dec.decode(b"4")
 
         with pytest.raises(msgspec.ValidationError, match="Expected `int`, got `str`"):
@@ -1226,7 +1226,7 @@ class TestLiteral:
         with pytest.raises(msgspec.ValidationError, match="Expected `str`, got `int`"):
             dec.decode(b"4")
 
-        with pytest.raises(msgspec.ValidationError, match="Invalid enum value 'bad'"):
+        with pytest.raises(msgspec.ValidationError, match="Invalid value 'bad'"):
             dec.decode(b'"bad"')
 
 
@@ -1943,7 +1943,7 @@ class TestDict:
         dec = msgspec.json.Decoder(Dict[Literal["a", "b"], int])
         assert dec.decode(b'{"a": 1, "b": 2}') == {"a": 1, "b": 2}
 
-        with pytest.raises(msgspec.ValidationError, match="Invalid enum value 'c'"):
+        with pytest.raises(msgspec.ValidationError, match="Invalid value 'c'"):
             dec.decode(b'{"a": 1, "c": 2}')
 
     def test_decode_dict_enum_key(self):
@@ -2068,7 +2068,7 @@ class TestDict:
         dec = msgspec.json.Decoder(Dict[Literal[-1, 2], int])
         assert dec.decode(b'{"-1": 10, "2": 20}') == {-1: 10, 2: 20}
 
-        with pytest.raises(msgspec.ValidationError, match="Invalid enum value 3"):
+        with pytest.raises(msgspec.ValidationError, match="Invalid value 3"):
             dec.decode(b'{"-1": 10, "3": 20}')
 
     def test_encode_dict_float_key(self):

--- a/tests/unit/test_json.py
+++ b/tests/unit/test_json.py
@@ -1211,7 +1211,7 @@ class TestLiteral:
     def test_int_literal_errors(self):
         dec = msgspec.json.Decoder(Literal[1, 2, 3])
 
-        with pytest.raises(msgspec.ValidationError, match="Invalid enum value 4"):
+        with pytest.raises(msgspec.ValidationError, match="Invalid value 4"):
             dec.decode(b"4")
 
         with pytest.raises(msgspec.ValidationError, match="Expected `int`, got `str`"):
@@ -1223,19 +1223,19 @@ class TestLiteral:
         with pytest.raises(msgspec.ValidationError, match="Expected `str`, got `int`"):
             dec.decode(b"4")
 
-        with pytest.raises(msgspec.ValidationError, match="Invalid enum value 'bad'"):
+        with pytest.raises(msgspec.ValidationError, match="Invalid value 'bad'"):
             dec.decode(b'"bad"')
 
     def test_bool_literal_true_only(self):
         dec = msgspec.json.Decoder(Literal[True])
         assert dec.decode(b"true") is True
-        with pytest.raises(msgspec.ValidationError, match="Invalid enum value False"):
+        with pytest.raises(msgspec.ValidationError, match="Invalid value False"):
             dec.decode(b"false")
 
     def test_bool_literal_false_only(self):
         dec = msgspec.json.Decoder(Literal[False])
         assert dec.decode(b"false") is False
-        with pytest.raises(msgspec.ValidationError, match="Invalid enum value True"):
+        with pytest.raises(msgspec.ValidationError, match="Invalid value True"):
             dec.decode(b"true")
 
     def test_bool_literal_errors(self):
@@ -1963,7 +1963,7 @@ class TestDict:
         dec = msgspec.json.Decoder(dict[Literal["a", "b"], int])
         assert dec.decode(b'{"a": 1, "b": 2}') == {"a": 1, "b": 2}
 
-        with pytest.raises(msgspec.ValidationError, match="Invalid enum value 'c'"):
+        with pytest.raises(msgspec.ValidationError, match="Invalid value 'c'"):
             dec.decode(b'{"a": 1, "c": 2}')
 
     def test_decode_dict_enum_key(self):
@@ -1973,9 +1973,7 @@ class TestDict:
             FruitStr.BANANA: 2,
         }
 
-        with pytest.raises(
-            msgspec.ValidationError, match="Invalid enum value 'carrot'"
-        ):
+        with pytest.raises(msgspec.ValidationError, match="Invalid value 'carrot'"):
             dec.decode(b'{"apple": 1, "carrot": 2}')
 
     def test_decode_dict_str_key_constraints(self):
@@ -2044,7 +2042,7 @@ class TestDict:
             FruitInt.BANANA: 20,
         }
 
-        with pytest.raises(msgspec.ValidationError, match="Invalid enum value 3"):
+        with pytest.raises(msgspec.ValidationError, match="Invalid value 3"):
             dec.decode(b'{"-1": 1, "3": 2}')
 
     @pytest.mark.parametrize("x", [-(2**63), 2**64 - 1])
@@ -2088,7 +2086,7 @@ class TestDict:
         dec = msgspec.json.Decoder(dict[Literal[-1, 2], int])
         assert dec.decode(b'{"-1": 10, "2": 20}') == {-1: 10, 2: 20}
 
-        with pytest.raises(msgspec.ValidationError, match="Invalid enum value 3"):
+        with pytest.raises(msgspec.ValidationError, match="Invalid value 3"):
             dec.decode(b'{"-1": 10, "3": 20}')
 
     def test_encode_dict_float_key(self):

--- a/tests/unit/test_msgpack.py
+++ b/tests/unit/test_msgpack.py
@@ -1008,13 +1008,13 @@ class TestTypedDecoder:
         assert dec.decode(enc.encode("one")) == "one"
 
         with pytest.raises(
-            msgspec.ValidationError, match="Invalid enum value 'MISSING'"
+            msgspec.ValidationError, match="Invalid value 'MISSING'"
         ):
             dec.decode(enc.encode("MISSING"))
 
         with pytest.raises(
             msgspec.ValidationError,
-            match=r"Invalid enum value 'MISSING' - at `\$\[0\]`",
+            match=r"Invalid value 'MISSING' - at `\$\[0\]`",
         ):
             msgspec.msgpack.decode(enc.encode(["MISSING"]), type=List[literal])
 
@@ -1025,11 +1025,11 @@ class TestTypedDecoder:
 
         assert dec.decode(enc.encode(1)) == 1
 
-        with pytest.raises(msgspec.ValidationError, match="Invalid enum value 1000"):
+        with pytest.raises(msgspec.ValidationError, match="Invalid value 1000"):
             dec.decode(enc.encode(1000))
 
         with pytest.raises(
-            msgspec.ValidationError, match=r"Invalid enum value 1000 - at `\$\[0\]`"
+            msgspec.ValidationError, match=r"Invalid value 1000 - at `\$\[0\]`"
         ):
             msgspec.msgpack.decode(enc.encode([1000]), type=List[literal])
 

--- a/tests/unit/test_msgpack.py
+++ b/tests/unit/test_msgpack.py
@@ -979,14 +979,12 @@ class TestTypedDecoder:
         with pytest.raises(msgspec.DecodeError, match="truncated"):
             dec.decode(a[:-2])
 
-        with pytest.raises(
-            msgspec.ValidationError, match="Invalid enum value 'MISSING'"
-        ):
+        with pytest.raises(msgspec.ValidationError, match="Invalid value 'MISSING'"):
             dec.decode(enc.encode("MISSING"))
 
         with pytest.raises(
             msgspec.ValidationError,
-            match=r"Invalid enum value 'MISSING' - at `\$\[0\]`",
+            match=r"Invalid value 'MISSING' - at `\$\[0\]`",
         ):
             msgspec.msgpack.decode(enc.encode(["MISSING"]), type=list[FruitStr])
 
@@ -1004,11 +1002,11 @@ class TestTypedDecoder:
         with pytest.raises(msgspec.DecodeError, match="truncated"):
             dec.decode(a[:-2])
 
-        with pytest.raises(msgspec.ValidationError, match="Invalid enum value 1000"):
+        with pytest.raises(msgspec.ValidationError, match="Invalid value 1000"):
             dec.decode(enc.encode(1000))
 
         with pytest.raises(
-            msgspec.ValidationError, match=r"Invalid enum value 1000 - at `\$\[0\]`"
+            msgspec.ValidationError, match=r"Invalid value 1000 - at `\$\[0\]`"
         ):
             msgspec.msgpack.decode(enc.encode([1000]), type=list[FruitInt])
 
@@ -1022,14 +1020,12 @@ class TestTypedDecoder:
 
         assert dec.decode(enc.encode("one")) == "one"
 
-        with pytest.raises(
-            msgspec.ValidationError, match="Invalid enum value 'MISSING'"
-        ):
+        with pytest.raises(msgspec.ValidationError, match="Invalid value 'MISSING'"):
             dec.decode(enc.encode("MISSING"))
 
         with pytest.raises(
             msgspec.ValidationError,
-            match=r"Invalid enum value 'MISSING' - at `\$\[0\]`",
+            match=r"Invalid value 'MISSING' - at `\$\[0\]`",
         ):
             msgspec.msgpack.decode(enc.encode(["MISSING"]), type=list[literal])
 
@@ -1040,11 +1036,11 @@ class TestTypedDecoder:
 
         assert dec.decode(enc.encode(1)) == 1
 
-        with pytest.raises(msgspec.ValidationError, match="Invalid enum value 1000"):
+        with pytest.raises(msgspec.ValidationError, match="Invalid value 1000"):
             dec.decode(enc.encode(1000))
 
         with pytest.raises(
-            msgspec.ValidationError, match=r"Invalid enum value 1000 - at `\$\[0\]`"
+            msgspec.ValidationError, match=r"Invalid value 1000 - at `\$\[0\]`"
         ):
             msgspec.msgpack.decode(enc.encode([1000]), type=list[literal])
 


### PR DESCRIPTION
Closes #1009.

Validation errors for `typing.Literal` types previously used the wording `Invalid enum value <val>`, which is misleading because the user is not using `enum.Enum` (see #1009).

Following the discussion below, this uses a single universal wording `Invalid value <val>` for both `Literal` and `Enum` (and the bool literals from #1004), rather than splitting the two by type. The target type is never named in the message, which resolves the "arbitrary distinction" concern and stays consistent with the existing union tag errors that already raise plain `Invalid value`.

Before:

```
Literal[1, 2, 3]   + 4       -> Invalid enum value 4
Fruit (Enum)       + "grape"  -> Invalid enum value 'grape'
```

After:

```
Literal[1, 2, 3]   + 4       -> Invalid value 4
Fruit (Enum)       + "grape"  -> Invalid value 'grape'
```

Tests and docs updated; full unit suite passes (6368 passed).
