### PR TITLE
Restore pytest-benchmark for local and manual profiling

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -92,6 +92,7 @@ test-base = [
 test-prof = [
   { include-group = "test-base" },
   "memray; sys_platform != 'win32'",
+  "pytest-benchmark",
   "pytest-codspeed",
   "pytest-memray; sys_platform != 'win32'",
 ]


### PR DESCRIPTION
Add `pytest-benchmark` back to the `test-prof` dependency group. This is required for benchmark execution with the existing `--benchmark-*` options in `just test-perf` and the Manual Profile workflow. When CodSpeed is enabled, its benchmark fixture is used instead.

The existing calibration options are accepted during argument parsing but are unused in the current tests. Restoring their effect is separate work; this PR only adds the missing dependency.