### PR TITLE
support msgpack encoding with integer keys

### DIFF
--- a/docs/structs.rst
+++ b/docs/structs.rst
@@ -896,25 +896,41 @@ rather than strings.
     >>> msgspec.msgpack.decode(buf, type=Point)
     Point(x=1, y=2)
 
-Integer keys only make sense for MessagePack — JSON object keys must be strings,
-so the **JSON encoder ignores** ``int_keys`` and continues to use the (possibly
-renamed) field names:
+JSON object keys must be strings, so in JSON the integer keys are encoded as their
+decimal strings (``"1"``, ``"2"``) — the same coercion msgspec uses for integer
+dict keys:
 
 .. code-block:: python
 
     >>> msgspec.json.encode(Point(1, 2))
-    b'{"x":1,"y":2}'
+    b'{"1":1,"2":2}'
+
+    >>> msgspec.json.decode(b'{"1":1,"2":2}', type=Point)
+    Point(x=1, y=2)
+
+Decoding also accepts the original field names, so a message that uses names (for
+example one produced with a plain ``rename``, or by a non-msgspec producer) still
+round-trips:
+
+.. code-block:: python
+
+    >>> msgspec.json.decode(b'{"x":1,"y":2}', type=Point)
+    Point(x=1, y=2)
 
 A few things to note:
 
-- Not every field needs a key; fields missing from ``int_keys`` keep their
-  string names on the wire (producing a message with mixed integer/string keys).
+- Not every field needs a key; fields missing from ``int_keys`` keep their string
+  names on the wire (producing a message with mixed integer and string keys).
 - Integer keys are baked onto the type, so **nested** structs are handled
   automatically — each struct encodes with its own ``int_keys``, with no extra
-  configuration needed at encode/decode time.
-- ``int_keys`` composes with ``rename`` (and ``field(name=...)``): the string
-  name is used for JSON, the integer for MessagePack.
+  configuration needed at encode/decode time. This also holds under
+  ``order="sorted"``, which emits the same integer keys.
+- ``int_keys`` composes with ``rename`` (and ``field(name=...)``): ``int_keys``
+  sets the wire key for the fields it lists, while ``rename`` still controls the
+  string key of any unlisted fields (and the name that JSON decoding falls back to).
 - Integer keys must be unique within a struct and fit in a signed 64-bit integer.
+- ``int_keys`` cannot be combined with ``array_like=True`` (array-encoded structs
+  have no field keys); doing so raises a ``ValueError`` at class definition.
 
 The assigned key for each field is available via introspection through the
 ``int_key`` attribute of `msgspec.structs.FieldInfo`:

--- a/docs/structs.rst
+++ b/docs/structs.rst
@@ -869,6 +869,62 @@ precedence.
     b'{"fieldX":1,"y":2}'
 
 
+Integer Field Keys
+------------------
+
+Descriptive field names make for readable code but bloat the encoded message,
+since the name of every field is repeated in full on the wire. For MessagePack
+you can avoid this by encoding fields with **integer keys** instead of their
+names, using the ``int_keys`` configuration option — a mapping from field name to
+integer. This is like renaming (above), but the wire keys are compact integers
+rather than strings.
+
+.. code-block:: python
+
+    >>> import msgspec
+
+    >>> class Point(msgspec.Struct, int_keys={"x": 1, "y": 2}):
+    ...     x: int
+    ...     y: int
+
+    >>> # MessagePack encodes the fields with integer keys ({1: 1, 2: 2})
+    >>> buf = msgspec.msgpack.encode(Point(1, 2))
+    >>> msgspec.msgpack.decode(buf)
+    {1: 1, 2: 2}
+
+    >>> # Decoding maps the integer keys back to fields
+    >>> msgspec.msgpack.decode(buf, type=Point)
+    Point(x=1, y=2)
+
+Integer keys only make sense for MessagePack — JSON object keys must be strings,
+so the **JSON encoder ignores** ``int_keys`` and continues to use the (possibly
+renamed) field names:
+
+.. code-block:: python
+
+    >>> msgspec.json.encode(Point(1, 2))
+    b'{"x":1,"y":2}'
+
+A few things to note:
+
+- Not every field needs a key; fields missing from ``int_keys`` keep their
+  string names on the wire (producing a message with mixed integer/string keys).
+- Integer keys are baked onto the type, so **nested** structs are handled
+  automatically — each struct encodes with its own ``int_keys``, with no extra
+  configuration needed at encode/decode time.
+- ``int_keys`` composes with ``rename`` (and ``field(name=...)``): the string
+  name is used for JSON, the integer for MessagePack.
+- Integer keys must be unique within a struct and fit in a signed 64-bit integer.
+
+The assigned key for each field is available via introspection through the
+``int_key`` attribute of `msgspec.structs.FieldInfo`:
+
+.. code-block:: python
+
+    >>> [(f.name, f.int_key) for f in msgspec.structs.fields(Point)]
+    [('x', 1), ('y', 2)]
+
+
 Encoding/Decoding as Arrays
 ---------------------------
 

--- a/docs/structs.rst
+++ b/docs/structs.rst
@@ -908,14 +908,45 @@ dict keys:
     >>> msgspec.json.decode(b'{"1":1,"2":2}', type=Point)
     Point(x=1, y=2)
 
-Decoding also accepts the original field names, so a message that uses names (for
-example one produced with a plain ``rename``, or by a non-msgspec producer) still
-round-trips:
+Only the exact decimal string the encoder emits is recognized as an integer key
+when decoding JSON: no leading zeros, no ``"-0"``, and a value within the signed
+64-bit range. Anything else (``"01"``, ``"9223372036854775808"``, ...) is treated
+as an ordinary, unknown field name.
+
+Decoding also accepts the field's encoded (string) name as an alias, so a message
+that uses names (for example one produced by a non-msgspec producer) still
+round-trips. The alias is a decoding convenience only; the encoder never emits it.
 
 .. code-block:: python
 
     >>> msgspec.json.decode(b'{"x":1,"y":2}', type=Point)
     Point(x=1, y=2)
+
+Because both spellings are accepted, the decimal string of an integer key must not
+also be the encoded name of a *different* field, or the ``tag_field`` of a tagged
+struct — otherwise two keys would be indistinguishable on the wire. Such
+collisions raise a ``ValueError`` at class definition:
+
+.. code-block:: python
+
+    >>> class Bad(msgspec.Struct, int_keys={"a": 1}, rename={"b": "1"}):
+    ...     a: int
+    ...     b: int = 0
+    Traceback (most recent call last):
+      ...
+    ValueError: `int_keys` value 1 for field 'a' conflicts with field 'b', whose encoded name is also '1'
+
+Generated :doc:`JSON schemas <jsonschema>` describe the encoded form: an
+int-keyed field appears under its decimal-string key (``"1"``), and is listed
+there in ``required`` if it has no default. The name alias is not part of the
+schema. Note that this means a schema generated with ``forbid_unknown_fields=True``
+(``additionalProperties: false``) rejects alias-keyed messages that msgspec itself
+would still accept.
+
+.. code-block:: python
+
+    >>> msgspec.json.schema(Point)["$defs"]["Point"]
+    {'title': 'Point', 'type': 'object', 'properties': {'1': {'type': 'integer'}, '2': {'type': 'integer'}}, 'required': ['1', '2']}
 
 A few things to note:
 
@@ -927,8 +958,11 @@ A few things to note:
   ``order="sorted"``, which emits the same integer keys.
 - ``int_keys`` composes with ``rename`` (and ``field(name=...)``): ``int_keys``
   sets the wire key for the fields it lists, while ``rename`` still controls the
-  string key of any unlisted fields (and the name that JSON decoding falls back to).
-- Integer keys must be unique within a struct and fit in a signed 64-bit integer.
+  string key of any unlisted fields (and the encoded name that decoding accepts
+  as an alias).
+- Integer keys must be unique within a struct, fit in a signed 64-bit integer
+  (``-2**63`` through ``2**63 - 1``), and not collide with another field's
+  encoded name or the ``tag_field`` as described above.
 - ``int_keys`` cannot be combined with ``array_like=True`` (array-encoded structs
   have no field keys); doing so raises a ``ValueError`` at class definition.
 

--- a/src/msgspec/__init__.pyi
+++ b/src/msgspec/__init__.pyi
@@ -50,6 +50,7 @@ class StructMeta(type):
             | Callable[[str], str | None]
             | Mapping[str, str]
         ) = None,
+        int_keys: Mapping[str, int] | None = None,
         omit_defaults: bool = False,
         forbid_unknown_fields: bool = False,
         frozen: bool = False,
@@ -105,6 +106,7 @@ class Struct(metaclass=StructMeta):
             | Callable[[str], str | None]
             | Mapping[str, str]
         ) = None,
+        int_keys: Mapping[str, int] | None = None,
         omit_defaults: bool = False,
         forbid_unknown_fields: bool = False,
         frozen: bool = False,
@@ -136,6 +138,7 @@ def defstruct(
         | Callable[[str], str | None]
         | Mapping[str, str]
     ) = None,
+    int_keys: Mapping[str, int] | None = None,
     omit_defaults: bool = False,
     forbid_unknown_fields: bool = False,
     frozen: bool = False,

--- a/src/msgspec/_core.c
+++ b/src/msgspec/_core.c
@@ -3036,6 +3036,10 @@ typedef struct {
     PyObject *struct_tag;        /* True, str, or NULL */
     PyObject *match_args;
     PyObject *rename;
+    /* int_keys: msgpack-only integer map keys. All NULL when unused. */
+    PyObject *struct_int_keys;         /* merged dict {field_name: PyLong} or NULL */
+    PyObject *struct_encode_int_keys;  /* tuple parallel to struct_encode_fields; PyLong or None per field, or NULL */
+    PyObject *struct_int_key_lookup;   /* IntLookup int64 -> PyLong(field_index) or NULL */
     PyObject *post_init;
     Py_ssize_t hash_offset;  /* 0 for no caching, otherwise offset */
     int8_t frozen;
@@ -5741,6 +5745,10 @@ typedef struct {
     PyObject *tag;
     PyObject *tag_field;
     PyObject *tag_value;
+    /* int_keys outputs. All owned references. */
+    PyObject *int_keys;            /* merged dict {field_name: PyLong} or NULL */
+    PyObject *encode_int_keys;     /* tuple or NULL */
+    PyObject *int_key_lookup;      /* IntLookup or NULL */
     Py_ssize_t *offsets;
     Py_ssize_t nkwonly;
     Py_ssize_t n_trailing_defaults;
@@ -5844,6 +5852,13 @@ structmeta_collect_base(StructMetaInfo *info, MsgspecState *mod, PyObject *base)
     }
     if (st_type->rename != NULL) {
         info->rename = st_type->rename;
+    }
+    if (st_type->struct_int_keys != NULL) {
+        if (info->int_keys == NULL) {
+            info->int_keys = PyDict_New();
+            if (info->int_keys == NULL) return -1;
+        }
+        if (PyDict_Update(info->int_keys, st_type->struct_int_keys) < 0) return -1;
     }
     info->frozen = STRUCT_MERGE_OPTIONS(info->frozen, st_type->frozen);
     info->eq = STRUCT_MERGE_OPTIONS(info->eq, st_type->eq);
@@ -6367,6 +6382,127 @@ structmeta_construct_encode_fields(StructMetaInfo *info)
     return 0;
 }
 
+/* Construct `encode_int_keys` (tuple parallel to encode_fields, PyLong or None)
+ * and `int_key_lookup` (IntLookup int64 -> PyLong(field_index)) from the merged
+ * `int_keys` mapping. No-op (leaves outputs NULL) when `int_keys` is unused. */
+static int
+structmeta_construct_int_keys(StructMetaInfo *info)
+{
+    if (info->int_keys == NULL || PyDict_GET_SIZE(info->int_keys) == 0) {
+        /* Nothing to do */
+        return 0;
+    }
+
+    Py_ssize_t nfields = PyTuple_GET_SIZE(info->fields);
+
+    /* Map field name -> index for validation/placement */
+    PyObject *field_index_lk = PyDict_New();
+    if (field_index_lk == NULL) return -1;
+    for (Py_ssize_t i = 0; i < nfields; i++) {
+        PyObject *index = PyLong_FromSsize_t(i);
+        if (index == NULL) {
+            Py_DECREF(field_index_lk);
+            return -1;
+        }
+        int status = PyDict_SetItem(
+            field_index_lk, PyTuple_GET_ITEM(info->fields, i), index
+        );
+        Py_DECREF(index);
+        if (status < 0) {
+            Py_DECREF(field_index_lk);
+            return -1;
+        }
+    }
+
+    PyObject *encode_int_keys = NULL, *reverse = NULL, *seen = NULL;
+    int ok = -1;
+
+    /* encode tuple: default all None */
+    encode_int_keys = PyTuple_New(nfields);
+    if (encode_int_keys == NULL) goto done;
+    for (Py_ssize_t i = 0; i < nfields; i++) {
+        Py_INCREF(Py_None);
+        PyTuple_SET_ITEM(encode_int_keys, i, Py_None);
+    }
+
+    /* reverse lookup dict: {int_key: PyLong(field_index)} */
+    reverse = PyDict_New();
+    if (reverse == NULL) goto done;
+    /* set of seen int keys for uniqueness */
+    seen = PySet_New(NULL);
+    if (seen == NULL) goto done;
+
+    PyObject *field_name, *key;
+    Py_ssize_t pos = 0;
+    while (PyDict_Next(info->int_keys, &pos, &field_name, &key)) {
+        /* field_name must name an existing field */
+        PyObject *index = PyDict_GetItem(field_index_lk, field_name);
+        if (index == NULL) {
+            PyErr_Format(
+                PyExc_ValueError,
+                "`int_keys` field %R does not exist in the struct",
+                field_name
+            );
+            goto done;
+        }
+        /* key must be an int within [-2**63, 2**63 - 1] */
+        if (!PyLong_CheckExact(key)) {
+            PyErr_Format(
+                PyExc_TypeError,
+                "`int_keys` values must be `int`, got value for field %R of type `%.200s`",
+                field_name, Py_TYPE(key)->tp_name
+            );
+            goto done;
+        }
+        int64_t ival = PyLong_AsLongLong(key);
+        if (ival == -1 && PyErr_Occurred()) {
+            PyErr_SetString(
+                PyExc_ValueError,
+                "Integer `int_keys` values must be within [-2**63, 2**63 - 1]"
+            );
+            goto done;
+        }
+        /* uniqueness of int values */
+        int contains = PySet_Contains(seen, key);
+        if (contains < 0) goto done;
+        if (contains) {
+            PyErr_SetString(
+                PyExc_ValueError,
+                "Multiple fields map to the same `int_keys` value, "
+                "integer keys must be unique"
+            );
+            goto done;
+        }
+        if (PySet_Add(seen, key) < 0) goto done;
+
+        /* place PyLong key in encode tuple at the field's index */
+        Py_ssize_t idx = PyLong_AsSsize_t(index);
+        Py_INCREF(key);
+        PyObject *old = PyTuple_GET_ITEM(encode_int_keys, idx);
+        PyTuple_SET_ITEM(encode_int_keys, idx, key);
+        Py_DECREF(old);
+
+        /* reverse[int_key] = PyLong(field_index) */
+        if (PyDict_SetItem(reverse, key, index) < 0) goto done;
+    }
+
+    /* Build the IntLookup from {int_key: PyLong(index)} */
+    PyObject *lookup = IntLookup_New(reverse, NULL, NULL, false);
+    if (lookup == NULL) goto done;
+
+    info->encode_int_keys = encode_int_keys;
+    encode_int_keys = NULL;  /* ownership transferred */
+    info->int_key_lookup = lookup;
+    ok = 0;
+
+done:
+    Py_XDECREF(field_index_lk);
+    Py_XDECREF(encode_int_keys);
+    Py_XDECREF(reverse);
+    Py_XDECREF(seen);
+    return ok;
+}
+
 /* Extracts the qualname for a class, and strips off any leading bits from a
  * function namespace. Examples:
  *
@@ -6517,6 +6653,7 @@ static PyObject *
 StructMeta_new_inner(
     PyTypeObject *type, PyObject *name, PyObject *bases, PyObject *namespace,
     PyObject *arg_tag_field, PyObject *arg_tag, PyObject *arg_rename,
+    PyObject *arg_int_keys,
     int arg_omit_defaults, int arg_forbid_unknown_fields,
     int arg_frozen, int arg_eq, int arg_order, bool arg_kw_only,
     int arg_repr_omit_defaults, int arg_array_like,
@@ -6542,6 +6679,9 @@ StructMeta_new_inner(
         .tag = NULL,
         .tag_field = NULL,
         .tag_value = NULL,
+        .int_keys = NULL,
+        .encode_int_keys = NULL,
+        .int_key_lookup = NULL,
         .offsets = NULL,
         .nkwonly = 0,
         .n_trailing_defaults = 0,
@@ -6595,6 +6735,14 @@ StructMeta_new_inner(
     if (arg_rename != NULL) {
         info.rename = arg_rename == Py_None ? NULL : arg_rename;
     }
+    if (arg_int_keys != NULL && arg_int_keys != Py_None) {
+        if (info.int_keys == NULL) {
+            info.int_keys = PyDict_New();
+            if (info.int_keys == NULL) goto cleanup;
+        }
+        /* PyDict_Update accepts any mapping with a keys() method */
+        if (PyDict_Update(info.int_keys, arg_int_keys) < 0) goto cleanup;
+    }
     info.frozen = STRUCT_MERGE_OPTIONS(info.frozen, arg_frozen);
     info.eq = STRUCT_MERGE_OPTIONS(info.eq, arg_eq);
     info.order = STRUCT_MERGE_OPTIONS(info.order, arg_order);
@@ -6636,6 +6784,9 @@ StructMeta_new_inner(
 
     /* Construct encode_fields */
     if (structmeta_construct_encode_fields(&info) < 0) goto cleanup;
+
+    /* Construct int_keys encode tuple & lookup */
+    if (structmeta_construct_int_keys(&info) < 0) goto cleanup;
 
     /* Construct type */
     PyObject *args = Py_BuildValue("(OOO)", name, bases, info.namespace);
@@ -6714,6 +6865,12 @@ StructMeta_new_inner(
     cls->struct_tag_value = info.tag_value;
     Py_XINCREF(info.rename);
     cls->rename = info.rename;
+    Py_XINCREF(info.int_keys);
+    cls->struct_int_keys = info.int_keys;
+    Py_XINCREF(info.encode_int_keys);
+    cls->struct_encode_int_keys = info.encode_int_keys;
+    Py_XINCREF(info.int_key_lookup);
+    cls->struct_int_key_lookup = info.int_key_lookup;
     cls->hash_offset = info.hash_offset;
     cls->frozen = info.frozen;
     cls->eq = info.eq;
@@ -6742,6 +6899,9 @@ cleanup:
     Py_XDECREF(info.tag);
     Py_XDECREF(info.tag_field);
     Py_XDECREF(info.tag_value);
+    Py_XDECREF(info.int_keys);
+    Py_XDECREF(info.encode_int_keys);
+    Py_XDECREF(info.int_key_lookup);
     if (!ok) {
         if (info.offsets != NULL) {
             PyMem_Free(info.offsets);
@@ -6757,6 +6917,7 @@ StructMeta_new(PyTypeObject *type, PyObject *args, PyObject *kwargs)
 {
     PyObject *name = NULL, *bases = NULL, *namespace = NULL;
     PyObject *arg_tag_field = NULL, *arg_tag = NULL, *arg_rename = NULL;
+    PyObject *arg_int_keys = NULL;
     int arg_omit_defaults = -1, arg_forbid_unknown_fields = -1;
     int arg_frozen = -1, arg_eq = -1, arg_order = -1, arg_repr_omit_defaults = -1;
     int arg_array_like = -1, arg_gc = -1, arg_weakref = -1, arg_dict = -1;
@@ -6764,7 +6925,7 @@ StructMeta_new(PyTypeObject *type, PyObject *args, PyObject *kwargs)
 
     char *kwlist[] = {
         "name", "bases", "dict",
-        "tag_field", "tag", "rename",
+        "tag_field", "tag", "rename", "int_keys",
         "omit_defaults", "forbid_unknown_fields",
         "frozen", "eq", "order", "kw_only",
         "repr_omit_defaults", "array_like",
@@ -6774,9 +6935,9 @@ StructMeta_new(PyTypeObject *type, PyObject *args, PyObject *kwargs)
 
     /* Parse arguments: (name, bases, dict) */
     if (!PyArg_ParseTupleAndKeywords(
-            args, kwargs, "UO!O!|$OOOpppppppppppp:StructMeta.__new__", kwlist,
+            args, kwargs, "UO!O!|$OOOOpppppppppppp:StructMeta.__new__", kwlist,
             &name, &PyTuple_Type, &bases, &PyDict_Type, &namespace,
-            &arg_tag_field, &arg_tag, &arg_rename,
+            &arg_tag_field, &arg_tag, &arg_rename, &arg_int_keys,
             &arg_omit_defaults, &arg_forbid_unknown_fields,
             &arg_frozen, &arg_eq, &arg_order, &arg_kw_only,
             &arg_repr_omit_defaults, &arg_array_like,
@@ -6787,7 +6948,7 @@ StructMeta_new(PyTypeObject *type, PyObject *args, PyObject *kwargs)
 
     return StructMeta_new_inner(
         type, name, bases, namespace,
-        arg_tag_field, arg_tag, arg_rename,
+        arg_tag_field, arg_tag, arg_rename, arg_int_keys,
         arg_omit_defaults, arg_forbid_unknown_fields,
         arg_frozen, arg_eq, arg_order, arg_kw_only,
         arg_repr_omit_defaults, arg_array_like,
@@ -6798,7 +6959,7 @@ StructMeta_new(PyTypeObject *type, PyObject *args, PyObject *kwargs)
 
 PyDoc_STRVAR(msgspec_defstruct__doc__,
 "defstruct(name, fields, *, bases=None, module=None, namespace=None, "
-"tag_field=None, tag=None, rename=None, omit_defaults=False, "
+"tag_field=None, tag=None, rename=None, int_keys=None, omit_defaults=False, "
 "forbid_unknown_fields=False, frozen=False, eq=True, order=False, "
 "kw_only=False, repr_omit_defaults=False, array_like=False, gc=True, "
 "weakref=False, dict=False, cache_hash=False)\n"
@@ -6850,6 +7011,7 @@ msgspec_defstruct(PyObject *self, PyObject *args, PyObject *kwargs)
 {
     PyObject *name = NULL, *fields = NULL, *bases = NULL, *module = NULL, *namespace = NULL;
     PyObject *arg_tag_field = NULL, *arg_tag = NULL, *arg_rename = NULL;
+    PyObject *arg_int_keys = NULL;
     PyObject *new_bases = NULL, *annotations = NULL, *fields_fast = NULL, *out = NULL;
     int arg_omit_defaults = -1, arg_forbid_unknown_fields = -1;
     int arg_frozen = -1, arg_eq = -1, arg_order = -1, arg_kw_only = 0;
@@ -6858,7 +7020,7 @@ msgspec_defstruct(PyObject *self, PyObject *args, PyObject *kwargs)
 
     char *kwlist[] = {
         "name", "fields", "bases", "module", "namespace",
-        "tag_field", "tag", "rename",
+        "tag_field", "tag", "rename", "int_keys",
         "omit_defaults", "forbid_unknown_fields",
         "frozen", "eq", "order", "kw_only",
         "repr_omit_defaults", "array_like",
@@ -6868,9 +7030,9 @@ msgspec_defstruct(PyObject *self, PyObject *args, PyObject *kwargs)
 
     /* Parse arguments: (name, bases, dict) */
     if (!PyArg_ParseTupleAndKeywords(
-            args, kwargs, "UO|$OOOOOOpppppppppppp:defstruct", kwlist,
+            args, kwargs, "UO|$OOOOOOOpppppppppppp:defstruct", kwlist,
             &name, &fields, &bases, &module, &namespace,
-            &arg_tag_field, &arg_tag, &arg_rename,
+            &arg_tag_field, &arg_tag, &arg_rename, &arg_int_keys,
             &arg_omit_defaults, &arg_forbid_unknown_fields,
             &arg_frozen, &arg_eq, &arg_order, &arg_kw_only,
             &arg_repr_omit_defaults, &arg_array_like,
@@ -6958,7 +7120,7 @@ msgspec_defstruct(PyObject *self, PyObject *args, PyObject *kwargs)
 
     out = StructMeta_new_inner(
         &StructMetaType, name, bases, namespace,
-        arg_tag_field, arg_tag, arg_rename,
+        arg_tag_field, arg_tag, arg_rename, arg_int_keys,
         arg_omit_defaults, arg_forbid_unknown_fields,
         arg_frozen, arg_eq, arg_order, arg_kw_only,
         arg_repr_omit_defaults, arg_array_like,
@@ -7150,6 +7312,9 @@ StructMeta_traverse(StructMetaObject *self, visitproc visit, void *arg)
     Py_VISIT(self->struct_encode_fields);
     Py_VISIT(self->struct_tag);  /* May be a function */
     Py_VISIT(self->rename);  /* May be a function */
+    Py_VISIT(self->struct_int_keys);
+    Py_VISIT(self->struct_encode_int_keys);
+    Py_VISIT(self->struct_int_key_lookup);
     Py_VISIT(self->post_init);
     Py_VISIT(self->struct_info);
     return PyType_Type.tp_traverse((PyObject *)self, visit, arg);
@@ -7168,6 +7333,9 @@ StructMeta_clear(StructMetaObject *self)
     Py_CLEAR(self->struct_tag_value);
     Py_CLEAR(self->struct_tag);
     Py_CLEAR(self->rename);
+    Py_CLEAR(self->struct_int_keys);
+    Py_CLEAR(self->struct_encode_int_keys);
+    Py_CLEAR(self->struct_int_key_lookup);
     Py_CLEAR(self->post_init);
     Py_CLEAR(self->struct_info);
     Py_CLEAR(self->match_args);
@@ -7482,6 +7650,7 @@ static PyMemberDef StructMeta_members[] = {
     {"__struct_fields__", T_OBJECT_EX, offsetof(StructMetaObject, struct_fields), READONLY, "Struct fields"},
     {"__struct_defaults__", T_OBJECT_EX, offsetof(StructMetaObject, struct_defaults), READONLY, "Struct defaults"},
     {"__struct_encode_fields__", T_OBJECT_EX, offsetof(StructMetaObject, struct_encode_fields), READONLY, "Struct encoded field names"},
+    {"__struct_encode_int_keys__", T_OBJECT, offsetof(StructMetaObject, struct_encode_int_keys), READONLY, "Per-field integer msgpack keys (tuple of int|None), or None if unused"},
     {"__match_args__", T_OBJECT_EX, offsetof(StructMetaObject, match_args), READONLY, "Positional match args"},
     {NULL},
 };
@@ -8602,6 +8771,13 @@ PyDoc_STRVAR(Struct__doc__,
 "   renamed names (missing fields are not renamed). Alternatively, may be a\n"
 "   callable that takes the field name and returns a new name or ``None`` to\n"
 "   not rename that field. Default is ``None`` for no field renaming.\n"
+"int_keys: mapping, or None, default None\n"
+"   A mapping from field name to a unique integer key, used only when encoding\n"
+"   or decoding this struct as **msgpack**. Listed fields are encoded using\n"
+"   their integer key instead of the field name (unlisted fields keep their\n"
+"   string name); decoding accepts both integer and string keys. This has no\n"
+"   effect on JSON, which always uses string field names. Composes with\n"
+"   ``rename`` (which stays str-only). Default is ``None``.\n"
 "repr_omit_defaults: bool, default False\n"
 "   Whether fields should be omitted from the generated repr if the\n"
 "   corresponding value is the default for that field.\n"
@@ -13311,11 +13487,131 @@ cleanup:
     return status;
 }
 
+/* Write the msgpack map key for struct field `i`. Uses the integer key when
+ * `int_keys` is configured for this field, otherwise the string field name. */
+static MS_INLINE int
+mpack_encode_struct_key(
+    EncoderState *self, StructMetaObject *struct_type, Py_ssize_t i, PyObject *key
+) {
+    if (MS_UNLIKELY(struct_type->struct_encode_int_keys != NULL)) {
+        PyObject *int_key = PyTuple_GET_ITEM(struct_type->struct_encode_int_keys, i);
+        if (int_key != Py_None) {
+            return mpack_encode_long(self, int_key);
+        }
+    }
+    return mpack_encode_str(self, key);
+}
+
+/* An entry for sorting an int-keyed struct under `order='sorted'`. Integer keys
+ * sort ascending and before any string keys (a stable total order across the two
+ * key kinds; a fully int-keyed struct is simply sorted by id). */
+typedef struct {
+    int is_int;
+    long long ikey;
+    const char *skey;
+    Py_ssize_t skey_size;
+    PyObject *keyobj;
+    PyObject *val;
+} MpStructSortItem;
+
+static MS_INLINE int
+_mp_struct_sortitem_lt(const MpStructSortItem *a, const MpStructSortItem *b) {
+    if (a->is_int != b->is_int) return a->is_int;  /* ints before strings */
+    if (a->is_int) return a->ikey < b->ikey;
+    Py_ssize_t n = (a->skey_size < b->skey_size) ? a->skey_size : b->skey_size;
+    int cmp = memcmp(a->skey, b->skey, n);
+    return (cmp < 0) || ((cmp == 0) & (a->skey_size < b->skey_size));
+}
+
+/* Encode an int-keyed struct with `order='sorted'`. The default assoclist sorted
+ * path is string-key only, so int-keyed structs get this dedicated path to keep
+ * their integer keys consistent across all `order` settings. Only reached when
+ * `order == ORDER_SORTED` and the struct has `int_keys`; the default (unsorted)
+ * encode path is untouched. */
+static int
+mpack_encode_struct_object_sorted_intkeys(
+    EncoderState *self, StructMetaObject *struct_type, PyObject *obj
+) {
+    PyObject *tag_field = struct_type->struct_tag_field;
+    PyObject *tag_value = struct_type->struct_tag_value;
+    PyObject *fields = struct_type->struct_encode_fields;
+    PyObject *int_keys = struct_type->struct_encode_int_keys;
+    PyObject *defaults = struct_type->struct_defaults;
+    Py_ssize_t nfields = PyTuple_GET_SIZE(fields);
+    Py_ssize_t npos = nfields - PyTuple_GET_SIZE(defaults);
+    bool omit_defaults = struct_type->omit_defaults == OPT_TRUE;
+    Py_ssize_t cap = nfields + (tag_value != NULL);
+    int status = -1;
+    MpStructSortItem *items = NULL;
+
+    if (Py_EnterRecursiveCall(" while serializing an object")) return -1;
+
+    if (cap > 0) {
+        items = PyMem_Malloc(cap * sizeof(MpStructSortItem));
+        if (items == NULL) { PyErr_NoMemory(); goto cleanup; }
+    }
+    Py_ssize_t n = 0;
+    if (tag_value != NULL) {
+        MpStructSortItem *it = &items[n++];
+        it->is_int = 0;
+        it->skey = unicode_str_and_size_nocheck(tag_field, &it->skey_size);
+        it->keyobj = tag_field;
+        it->val = tag_value;
+    }
+    for (Py_ssize_t i = 0; i < nfields; i++) {
+        PyObject *val = Struct_get_index(obj, i);
+        if (MS_UNLIKELY(val == NULL)) goto cleanup;
+        if (MS_UNLIKELY(val == UNSET)) continue;
+        if (omit_defaults && i >= npos
+                && is_default(val, PyTuple_GET_ITEM(defaults, i - npos))) {
+            continue;
+        }
+        MpStructSortItem *it = &items[n++];
+        PyObject *ik = PyTuple_GET_ITEM(int_keys, i);
+        if (ik != Py_None) {
+            it->is_int = 1;
+            it->ikey = PyLong_AsLongLong(ik);  /* range-validated at class creation */
+            it->keyobj = ik;
+        }
+        else {
+            it->is_int = 0;
+            it->skey = unicode_str_and_size_nocheck(PyTuple_GET_ITEM(fields, i), &it->skey_size);
+            it->keyobj = PyTuple_GET_ITEM(fields, i);
+        }
+        it->val = val;
+    }
+
+    /* insertion sort -- struct field counts are small */
+    for (Py_ssize_t i = 1; i < n; i++) {
+        MpStructSortItem tmp = items[i];
+        Py_ssize_t j = i;
+        while (j > 0 && _mp_struct_sortitem_lt(&tmp, &items[j - 1])) {
+            items[j] = items[j - 1];
+            j--;
+        }
+        items[j] = tmp;
+    }
+
+    if (mpack_encode_map_header(self, n, "structs") < 0) goto cleanup;
+    for (Py_ssize_t i = 0; i < n; i++) {
+        if (mpack_encode(self, items[i].keyobj) < 0) goto cleanup;
+        if (mpack_encode(self, items[i].val) < 0) goto cleanup;
+    }
+    status = 0;
+cleanup:
+    if (items != NULL) PyMem_Free(items);
+    Py_LeaveRecursiveCall();
+    return status;
+}
+
 static int
 mpack_encode_struct_object(
     EncoderState *self, StructMetaObject *struct_type, PyObject *obj
 ) {
     if (MS_UNLIKELY(self->order == ORDER_SORTED)) {
+        if (struct_type->struct_encode_int_keys != NULL) {
+            return mpack_encode_struct_object_sorted_intkeys(self, struct_type, obj);
+        }
         return mpack_encode_and_free_assoclist(self, AssocList_FromStruct(obj));
     }
 
@@ -13349,7 +13645,7 @@ mpack_encode_struct_object(
             actual_len--;
         }
         else {
-            if (mpack_encode_str(self, key) < 0) goto cleanup;
+            if (mpack_encode_struct_key(self, struct_type, i, key) < 0) goto cleanup;
             if (mpack_encode(self, val) < 0) goto cleanup;
         }
     }
@@ -13364,7 +13660,7 @@ mpack_encode_struct_object(
             actual_len--;
         }
         else {
-            if (mpack_encode_str(self, key) < 0) goto cleanup;
+            if (mpack_encode_struct_key(self, struct_type, i, key) < 0) goto cleanup;
             if (mpack_encode(self, val) < 0) goto cleanup;
         }
     }
@@ -16398,6 +16694,60 @@ mpack_decode_struct_map(
 
     for (i = 0; i < size; i++) {
         PathNode key_path = {path, PATH_KEY, NULL};
+
+        /* int_keys: if configured, peek the next lead byte. If it's an integer
+         * key, decode it and resolve via the int_key_lookup. Otherwise fall
+         * through to the normal string-key path (handles str fields, tag field,
+         * and unknown string keys). */
+        if (
+            MS_UNLIKELY(st_type->struct_int_key_lookup != NULL)
+            && self->input_pos != self->input_end
+        ) {
+            unsigned char lead = (unsigned char)(*self->input_pos);
+            bool is_int_key = (
+                lead <= 0x7f            /* positive fixint */
+                || lead >= 0xe0         /* negative fixint */
+                || (lead >= 0xcc && lead <= 0xd3)  /* uint/int 8..64 */
+            );
+            if (is_int_key) {
+                int64_t ikey = 0;
+                uint64_t uikey = 0;
+                if (mpack_decode_cint(self, &ikey, &uikey, &key_path) < 0) goto error;
+                PyObject *index_obj = NULL;
+                if (uikey == 0) {
+                    index_obj = IntLookup_GetInt64(
+                        (IntLookup *)st_type->struct_int_key_lookup, ikey
+                    );
+                }
+                else {
+                    index_obj = IntLookup_GetUInt64(
+                        (IntLookup *)st_type->struct_int_key_lookup, uikey
+                    );
+                }
+                if (index_obj == NULL) {
+                    /* Unknown integer key */
+                    if (MS_UNLIKELY(st_type->forbid_unknown_fields == OPT_TRUE)) {
+                        if (uikey == 0) {
+                            ms_invalid_cint_value(ikey, path);
+                        }
+                        else {
+                            ms_invalid_cuint_value(uikey, path);
+                        }
+                        goto error;
+                    }
+                    if (mpack_skip(self) < 0) goto error;
+                    continue;
+                }
+                /* index_obj is a borrowed PyLong(field_index) */
+                field_index = PyLong_AsSsize_t(index_obj);
+                PathNode field_path = {path, field_index, (PyObject *)st_type};
+                val = mpack_decode(self, info->types[field_index], &field_path, is_key);
+                if (val == NULL) goto error;
+                Struct_set_index(res, field_index, val);
+                continue;
+            }
+        }
+
         key_size = mpack_decode_cstr(self, &key, &key_path);
         if (MS_UNLIKELY(key_size < 0)) goto error;
 

--- a/src/msgspec/_core.c
+++ b/src/msgspec/_core.c
@@ -6393,6 +6393,15 @@ structmeta_construct_int_keys(StructMetaInfo *info)
         return 0;
     }
 
+    if (info->array_like == OPT_TRUE) {
+        PyErr_SetString(
+            PyExc_ValueError,
+            "Cannot use `int_keys` with `array_like=True` - array-encoded structs "
+            "have no field keys"
+        );
+        return -1;
+    }
+
     Py_ssize_t nfields = PyTuple_GET_SIZE(info->fields);
 
     /* Map field name -> index for validation/placement */
@@ -14936,11 +14945,125 @@ json_encode_struct_tag(EncoderState *self, PyObject *obj)
     }
 }
 
+/* Write a struct field's JSON object key. When the field has an `int_keys` entry
+ * the integer is written as a JSON string (e.g. `"1"`) -- JSON object keys must be
+ * strings, so the integer key is coerced to its decimal string, matching how
+ * integer dict keys are encoded. Otherwise the (string) field name is used. */
+static MS_INLINE int
+json_encode_struct_key(
+    EncoderState *self, StructMetaObject *struct_type, Py_ssize_t i, PyObject *key
+) {
+    if (MS_UNLIKELY(struct_type->struct_encode_int_keys != NULL)) {
+        PyObject *int_key = PyTuple_GET_ITEM(struct_type->struct_encode_int_keys, i);
+        if (int_key != Py_None) {
+            return json_encode_long_as_str(self, int_key);
+        }
+    }
+    return json_encode_str_noescape(self, key);
+}
+
+/* Encode an int-keyed struct as JSON with `order='sorted'`. The default assoclist
+ * sorted path is string-key only, so int-keyed structs get this dedicated path to
+ * keep the integer (string-coerced) keys consistent across all `order` settings.
+ * Only reached under `order == ORDER_SORTED` for structs with `int_keys`. Reuses
+ * the msgpack sort-item build/comparator; only the emission is JSON. */
+static int
+json_encode_struct_object_sorted_intkeys(
+    EncoderState *self, StructMetaObject *struct_type, PyObject *obj
+) {
+    PyObject *tag_field = struct_type->struct_tag_field;
+    PyObject *tag_value = struct_type->struct_tag_value;
+    PyObject *fields = struct_type->struct_encode_fields;
+    PyObject *int_keys = struct_type->struct_encode_int_keys;
+    PyObject *defaults = struct_type->struct_defaults;
+    Py_ssize_t nfields = PyTuple_GET_SIZE(fields);
+    Py_ssize_t npos = nfields - PyTuple_GET_SIZE(defaults);
+    bool omit_defaults = struct_type->omit_defaults == OPT_TRUE;
+    Py_ssize_t cap = nfields + (tag_value != NULL);
+    int status = -1;
+    MpStructSortItem *items = NULL;
+
+    if (Py_EnterRecursiveCall(" while serializing an object")) return -1;
+
+    if (cap > 0) {
+        items = PyMem_Malloc(cap * sizeof(MpStructSortItem));
+        if (items == NULL) { PyErr_NoMemory(); goto cleanup; }
+    }
+    Py_ssize_t n = 0;
+    if (tag_value != NULL) {
+        MpStructSortItem *it = &items[n++];
+        it->is_int = 0;
+        it->skey = unicode_str_and_size_nocheck(tag_field, &it->skey_size);
+        it->keyobj = tag_field;
+        it->val = tag_value;
+    }
+    for (Py_ssize_t i = 0; i < nfields; i++) {
+        PyObject *val = Struct_get_index(obj, i);
+        if (MS_UNLIKELY(val == NULL)) goto cleanup;
+        if (MS_UNLIKELY(val == UNSET)) continue;
+        if (omit_defaults && i >= npos
+                && is_default(val, PyTuple_GET_ITEM(defaults, i - npos))) {
+            continue;
+        }
+        MpStructSortItem *it = &items[n++];
+        PyObject *ik = PyTuple_GET_ITEM(int_keys, i);
+        if (ik != Py_None) {
+            it->is_int = 1;
+            it->ikey = PyLong_AsLongLong(ik);
+            it->keyobj = ik;
+        }
+        else {
+            it->is_int = 0;
+            it->skey = unicode_str_and_size_nocheck(PyTuple_GET_ITEM(fields, i), &it->skey_size);
+            it->keyobj = PyTuple_GET_ITEM(fields, i);
+        }
+        it->val = val;
+    }
+
+    /* insertion sort -- struct field counts are small */
+    for (Py_ssize_t i = 1; i < n; i++) {
+        MpStructSortItem tmp = items[i];
+        Py_ssize_t j = i;
+        while (j > 0 && _mp_struct_sortitem_lt(&tmp, &items[j - 1])) {
+            items[j] = items[j - 1];
+            j--;
+        }
+        items[j] = tmp;
+    }
+
+    if (ms_write(self, "{", 1) < 0) goto cleanup;
+    if (n == 0) {
+        status = ms_write(self, "}", 1);
+        goto cleanup;
+    }
+    for (Py_ssize_t i = 0; i < n; i++) {
+        if (items[i].is_int) {
+            if (json_encode_long_as_str(self, items[i].keyobj) < 0) goto cleanup;
+        }
+        else {
+            if (json_encode_str(self, items[i].keyobj) < 0) goto cleanup;
+        }
+        if (ms_write(self, ":", 1) < 0) goto cleanup;
+        if (json_encode(self, items[i].val) < 0) goto cleanup;
+        if (ms_write(self, ",", 1) < 0) goto cleanup;
+    }
+    /* Overwrite trailing comma with } */
+    *(self->output_buffer_raw + self->output_len - 1) = '}';
+    status = 0;
+cleanup:
+    if (items != NULL) PyMem_Free(items);
+    Py_LeaveRecursiveCall();
+    return status;
+}
+
 static int
 json_encode_struct_object(
     EncoderState *self, StructMetaObject *struct_type, PyObject *obj
 ) {
     if (MS_UNLIKELY(self->order == ORDER_SORTED)) {
+        if (struct_type->struct_encode_int_keys != NULL) {
+            return json_encode_struct_object_sorted_intkeys(self, struct_type, obj);
+        }
         return json_encode_and_free_assoclist(self, AssocList_FromStruct(obj), false);
     }
     PyObject *key, *val, *fields, *defaults, *tag_field, *tag_value;
@@ -14971,7 +15094,7 @@ json_encode_struct_object(
         val = Struct_get_index(obj, i);
         if (MS_UNLIKELY(val == NULL)) goto cleanup;
         if (MS_UNLIKELY(val == UNSET)) continue;
-        if (json_encode_str_noescape(self, key) < 0) goto cleanup;
+        if (json_encode_struct_key(self, struct_type, i, key) < 0) goto cleanup;
         if (ms_write(self, ":", 1) < 0) goto cleanup;
         if (json_encode(self, val) < 0) goto cleanup;
         if (ms_write(self, ",", 1) < 0) goto cleanup;
@@ -14983,7 +15106,7 @@ json_encode_struct_object(
         if (MS_UNLIKELY(val == UNSET)) continue;
         PyObject *default_val = PyTuple_GET_ITEM(defaults, i - nunchecked);
         if (!is_default(val, default_val)) {
-            if (json_encode_str_noescape(self, key) < 0) goto cleanup;
+            if (json_encode_struct_key(self, struct_type, i, key) < 0) goto cleanup;
             if (ms_write(self, ":", 1) < 0) goto cleanup;
             if (json_encode(self, val) < 0) goto cleanup;
             if (ms_write(self, ",", 1) < 0) goto cleanup;
@@ -16807,6 +16930,23 @@ mpack_decode_struct_union(
     for (Py_ssize_t i = 0; i < size; i++) {
         Py_ssize_t key_size;
         char *key = NULL;
+
+        /* Only a string key can be the (string) tag field. Peek the key's type
+         * and skip any non-string key -- e.g. an integer key from a struct with
+         * `int_keys` -- so the tag is found regardless of its position, matching
+         * the order-independence of plain string-keyed unions. */
+        if (MS_UNLIKELY(self->input_pos == self->input_end)) {
+            ms_err_truncated();
+            return NULL;
+        }
+        char op = *self->input_pos;
+        bool is_str = ('\xa0' <= op && op <= '\xbf')
+            || op == MP_STR8 || op == MP_STR16 || op == MP_STR32;
+        if (!is_str) {
+            if (mpack_skip(self) < 0) return NULL;   /* skip the non-string key */
+            if (mpack_skip(self) < 0) return NULL;   /* skip its value */
+            continue;
+        }
 
         key_size = mpack_decode_cstr(self, &key, &key_path);
         if (key_size < 0) return NULL;
@@ -19320,6 +19460,33 @@ error:
     return NULL;
 }
 
+/* Resolve a JSON string object key that encodes an `int_keys` integer id (e.g.
+ * "1") to a field index via the struct's int-key lookup. Returns -1 if the key is
+ * not a plain decimal integer or isn't a mapped int key -- the caller then falls
+ * back to matching it as a field name (so an `order='sorted'` message, which uses
+ * field names, and foreign name-keyed JSON both still decode). */
+static Py_ssize_t
+json_struct_int_key_index(StructMetaObject *st_type, const char *key, Py_ssize_t key_size) {
+    if (key_size == 0 || key_size > 19) return -1;
+    Py_ssize_t i = 0;
+    bool neg = false;
+    if (key[0] == '-') {
+        if (key_size == 1) return -1;
+        neg = true;
+        i = 1;
+    }
+    int64_t val = 0;
+    for (; i < key_size; i++) {
+        char c = key[i];
+        if (c < '0' || c > '9') return -1;
+        val = val * 10 + (c - '0');
+    }
+    if (neg) val = -val;
+    PyObject *idx = IntLookup_GetInt64((IntLookup *)st_type->struct_int_key_lookup, val);
+    if (idx == NULL) return -1;
+    return PyLong_AsSsize_t(idx);
+}
+
 static PyObject *
 json_decode_struct_map_inner(
     JSONDecoderState *self, StructInfo *info, PathNode *path,
@@ -19384,7 +19551,13 @@ json_decode_struct_map_inner(
         self->input_pos++;
 
         /* Parse value */
-        field_index = StructMeta_get_field_index(st_type, key, key_size, &pos);
+        field_index = -1;
+        if (MS_UNLIKELY(st_type->struct_int_key_lookup != NULL)) {
+            field_index = json_struct_int_key_index(st_type, key, key_size);
+        }
+        if (field_index < 0) {
+            field_index = StructMeta_get_field_index(st_type, key, key_size, &pos);
+        }
         if (MS_LIKELY(field_index >= 0)) {
             field_path.index = field_index;
             TypeNode *type = info->types[field_index];

--- a/src/msgspec/_core.c
+++ b/src/msgspec/_core.c
@@ -6484,8 +6484,39 @@ structmeta_construct_int_keys(StructMetaInfo *info)
         }
         if (PySet_Add(seen, key) < 0) goto done;
 
-        /* place PyLong key in encode tuple at the field's index */
         Py_ssize_t idx = PyLong_AsSsize_t(index);
+
+        /* In JSON an int key is written as its decimal string, and decoding
+         * accepts both that string and the field's encoded name. The decimal
+         * string must therefore not also be the encoded name of a *different*
+         * field (e.g. int key 1 alongside a field renamed to "1"), or the two
+         * fields would be indistinguishable on the wire. The same field carrying
+         * both spellings is unambiguous and allowed. The tag field is checked
+         * separately once the tag is constructed. */
+        PyObject *key_str = PyObject_Str(key);
+        if (key_str == NULL) goto done;
+        for (Py_ssize_t j = 0; j < nfields; j++) {
+            if (j == idx) continue;
+            PyObject *other = PyTuple_GET_ITEM(info->encode_fields, j);
+            int eq = PyObject_RichCompareBool(other, key_str, Py_EQ);
+            if (eq < 0) {
+                Py_DECREF(key_str);
+                goto done;
+            }
+            if (eq) {
+                PyErr_Format(
+                    PyExc_ValueError,
+                    "`int_keys` value %R for field %R conflicts with field %R, "
+                    "whose encoded name is also '%U'",
+                    key, field_name, PyTuple_GET_ITEM(info->fields, j), key_str
+                );
+                Py_DECREF(key_str);
+                goto done;
+            }
+        }
+        Py_DECREF(key_str);
+
+        /* place PyLong key in encode tuple at the field's index */
         Py_INCREF(key);
         PyObject *old = PyTuple_GET_ITEM(encode_int_keys, idx);
         PyTuple_SET_ITEM(encode_int_keys, idx, key);
@@ -6609,6 +6640,29 @@ structmeta_construct_tag(StructMetaInfo *info, MsgspecState *mod, PyObject *cls)
             info->tag_field
         );
         return -1;
+    }
+    /* In JSON an int key is written as its decimal string, so the tag field
+     * must not spell one of those either (e.g. `tag_field="1"` with int key 1),
+     * or the tag and that field would share a key on the wire. */
+    if (info->encode_int_keys != NULL) {
+        Py_ssize_t nfields = PyTuple_GET_SIZE(info->encode_int_keys);
+        for (Py_ssize_t i = 0; i < nfields; i++) {
+            PyObject *int_key = PyTuple_GET_ITEM(info->encode_int_keys, i);
+            if (int_key == Py_None) continue;
+            PyObject *key_str = PyObject_Str(int_key);
+            if (key_str == NULL) return -1;
+            int eq = PyObject_RichCompareBool(info->tag_field, key_str, Py_EQ);
+            Py_DECREF(key_str);
+            if (eq < 0) return -1;
+            if (eq) {
+                PyErr_Format(
+                    PyExc_ValueError,
+                    "`tag_field='%U' conflicts with the `int_keys` value %R of field %R",
+                    info->tag_field, int_key, PyTuple_GET_ITEM(info->fields, i)
+                );
+                return -1;
+            }
+        }
     }
     return 0;
 }
@@ -8781,12 +8835,15 @@ PyDoc_STRVAR(Struct__doc__,
 "   callable that takes the field name and returns a new name or ``None`` to\n"
 "   not rename that field. Default is ``None`` for no field renaming.\n"
 "int_keys: mapping, or None, default None\n"
-"   A mapping from field name to a unique integer key, used only when encoding\n"
-"   or decoding this struct as **msgpack**. Listed fields are encoded using\n"
-"   their integer key instead of the field name (unlisted fields keep their\n"
-"   string name); decoding accepts both integer and string keys. This has no\n"
-"   effect on JSON, which always uses string field names. Composes with\n"
-"   ``rename`` (which stays str-only). Default is ``None``.\n"
+"   A mapping from field name to a unique integer key. Listed fields are\n"
+"   encoded using their integer key instead of the field name (unlisted fields\n"
+"   keep their string name). In msgpack the key is an integer; in JSON, where\n"
+"   object keys must be strings, it is the integer's decimal string (e.g.\n"
+"   ``\"1\"``). Decoding accepts both the integer key and the field's encoded\n"
+"   name. Keys must be unique, fit in a signed 64-bit integer, and their\n"
+"   decimal string must not equal another field's encoded name or the\n"
+"   ``tag_field``. Composes with ``rename`` (which stays str-only). Cannot be\n"
+"   combined with ``array_like=True``. Default is ``None``.\n"
 "repr_omit_defaults: bool, default False\n"
 "   Whether fields should be omitted from the generated repr if the\n"
 "   corresponding value is the default for that field.\n"
@@ -19461,27 +19518,47 @@ error:
 }
 
 /* Resolve a JSON string object key that encodes an `int_keys` integer id (e.g.
- * "1") to a field index via the struct's int-key lookup. Returns -1 if the key is
- * not a plain decimal integer or isn't a mapped int key -- the caller then falls
- * back to matching it as a field name (so an `order='sorted'` message, which uses
- * field names, and foreign name-keyed JSON both still decode). */
+ * "1") to a field index via the struct's int-key lookup.
+ *
+ * Only the canonical decimal form that the encoder emits is recognized: an
+ * optional leading '-', no leading zeros, no "-0", and a value within the
+ * signed 64-bit range [-2**63, 2**63 - 1]. Any other key (non-canonical, out of
+ * range, or not a mapped id) returns -1 and the caller falls back to matching
+ * it as a field name -- so a name-keyed message from another producer still
+ * decodes, while a key like "9223372036854775808" is treated as an unknown
+ * field rather than silently wrapping onto a different field's id. */
 static Py_ssize_t
 json_struct_int_key_index(StructMetaObject *st_type, const char *key, Py_ssize_t key_size) {
-    if (key_size == 0 || key_size > 19) return -1;
+    /* Longest canonical keys: 19 digits, or '-' followed by 19 digits */
+    if (key_size == 0 || key_size > 20) return -1;
     Py_ssize_t i = 0;
     bool neg = false;
     if (key[0] == '-') {
-        if (key_size == 1) return -1;
         neg = true;
         i = 1;
     }
-    int64_t val = 0;
+    Py_ssize_t ndigits = key_size - i;
+    if (ndigits == 0 || ndigits > 19) return -1;
+    /* Reject leading zeros ("01") and "-0"; a lone "0" is fine */
+    if (key[i] == '0' && (ndigits > 1 || neg)) return -1;
+    /* At most 19 decimal digits always fit in a uint64_t, so this accumulation
+     * cannot overflow; the signed range is checked explicitly below. */
+    uint64_t uval = 0;
     for (; i < key_size; i++) {
         char c = key[i];
         if (c < '0' || c > '9') return -1;
-        val = val * 10 + (c - '0');
+        uval = uval * 10 + (uint64_t)(c - '0');
     }
-    if (neg) val = -val;
+    int64_t val;
+    if (neg) {
+        if (uval > (uint64_t)LLONG_MAX + 1) return -1;  /* below -2**63 */
+        /* Negate without ever forming +2**63 in signed arithmetic */
+        val = (uval == (uint64_t)LLONG_MAX + 1) ? LLONG_MIN : -(int64_t)uval;
+    }
+    else {
+        if (uval > (uint64_t)LLONG_MAX) return -1;  /* above 2**63 - 1 */
+        val = (int64_t)uval;
+    }
     PyObject *idx = IntLookup_GetInt64((IntLookup *)st_type->struct_int_key_lookup, val);
     if (idx == NULL) return -1;
     return PyLong_AsSsize_t(idx);

--- a/src/msgspec/_json_schema.py
+++ b/src/msgspec/_json_schema.py
@@ -402,13 +402,22 @@ class _SchemaGenerator:
 
             for field in t.fields:
                 field_schema = self.to_schema(field.type)
+                # The schema describes the encoded (wire) form. A field with an
+                # `int_keys` entry is written under its integer key's decimal
+                # string (e.g. "1") rather than its name. Decoding also accepts
+                # the encoded name as an alias, but that leniency is not part of
+                # the schema, matching how the encoder never emits it.
+                if field.int_key is not None:
+                    key = str(field.int_key)
+                else:
+                    key = field.encode_name
                 if field.required:
-                    required.append(field.encode_name)
+                    required.append(key)
                 elif field.default is not mi.NODEFAULT:
                     field_schema["default"] = to_builtins(field.default, str_keys=True)
                 elif field.default_factory in (list, dict, set, bytearray):
                     field_schema["default"] = field.default_factory()
-                names.append(field.encode_name)
+                names.append(key)
                 fields.append(field_schema)
 
             if t.array_like:

--- a/src/msgspec/inspect.py
+++ b/src/msgspec/inspect.py
@@ -513,6 +513,10 @@ class Field(msgspec.Struct):
     default_factory: Any, optional
         A callable that creates a default value for the field. Will be
         `NODEFAULT` if no ``default_factory`` is set.
+    int_key: int or None, optional
+        The integer key used in place of ``encode_name`` when encoding the
+        field, if the field is listed in a struct's ``int_keys`` mapping. Only
+        set for `StructType` fields; ``None`` otherwise.
     """
 
     name: str
@@ -521,6 +525,7 @@ class Field(msgspec.Struct):
     required: bool = True
     default: Any = msgspec.field(default_factory=lambda: NODEFAULT)
     default_factory: Any = msgspec.field(default_factory=lambda: NODEFAULT)
+    int_key: Union[int, None] = None
 
 
 class TypedDictType(Type):
@@ -941,11 +946,15 @@ class _Translator:
 
             hints = self._get_class_annotations(cls)
             npos = len(t.__struct_fields__) - len(t.__struct_defaults__)
+            int_keys = t.__struct_encode_int_keys__ or (None,) * len(
+                t.__struct_fields__
+            )
             fields = []
-            for name, encode_name, default_obj in zip(
+            for name, encode_name, default_obj, int_key in zip(
                 t.__struct_fields__,
                 t.__struct_encode_fields__,
                 (NODEFAULT,) * npos + t.__struct_defaults__,
+                int_keys,
             ):
                 if default_obj is NODEFAULT:
                     required = True
@@ -966,6 +975,7 @@ class _Translator:
                     required=required,
                     default=default,
                     default_factory=default_factory,
+                    int_key=int_key,
                 )
                 fields.append(field)
 

--- a/src/msgspec/structs.py
+++ b/src/msgspec/structs.py
@@ -47,6 +47,10 @@ class FieldInfo(Struct):
     default_factory: Any, optional
         A callable that creates a default value for the field. Will be
         `NODEFAULT` if no ``default_factory`` is set.
+    int_key: int or None, optional
+        The integer key used when encoding/decoding the field as msgpack, if the
+        field is configured via the struct's ``int_keys`` mapping. ``None`` if the
+        field uses its (string) ``encode_name`` instead.
     """
 
     name: str
@@ -54,6 +58,7 @@ class FieldInfo(Struct):
     type: Any
     default: Any = field(default_factory=lambda: NODEFAULT)
     default_factory: Any = field(default_factory=lambda: NODEFAULT)
+    int_key: "int | None" = None
 
     @property
     def required(self) -> bool:
@@ -90,12 +95,13 @@ def fields(type_or_instance: Struct | type[Struct]) -> tuple[FieldInfo]:
 
     hints = _get_class_annotations(annotated_cls)
     npos = len(cls.__struct_fields__) - len(cls.__struct_defaults__)
+    encode_int_keys = cls.__struct_encode_int_keys__  # tuple[int|None] or None
     fields = []
-    for name, encode_name, default_obj in zip(
+    for idx, (name, encode_name, default_obj) in enumerate(zip(
         cls.__struct_fields__,
         cls.__struct_encode_fields__,
         (NODEFAULT,) * npos + cls.__struct_defaults__,
-    ):
+    )):
         default = default_factory = NODEFAULT
         if isinstance(default_obj, _Factory):
             default_factory = default_obj.factory
@@ -108,6 +114,7 @@ def fields(type_or_instance: Struct | type[Struct]) -> tuple[FieldInfo]:
             type=hints[name],
             default=default,
             default_factory=default_factory,
+            int_key=None if encode_int_keys is None else encode_int_keys[idx],
         )
         fields.append(field)
 

--- a/src/msgspec/structs.pyi
+++ b/src/msgspec/structs.pyi
@@ -31,6 +31,7 @@ class FieldInfo(Struct):
     type: Any
     default: Any = NODEFAULT
     default_factory: Any = NODEFAULT
+    int_key: int | None = None
 
     @property
     def required(self) -> bool: ...

--- a/tests/unit/test_inspect.py
+++ b/tests/unit/test_inspect.py
@@ -478,6 +478,22 @@ def test_struct_encode_name():
     assert mi.type_info(Example) == sol
 
 
+def test_struct_int_key():
+    class Example(msgspec.Struct, int_keys={"field_one": 1}, rename="camel"):
+        field_one: int
+        field_two: int
+
+    sol = mi.StructType(
+        Example,
+        fields=(
+            mi.Field("field_one", "fieldOne", mi.IntType(), int_key=1),
+            mi.Field("field_two", "fieldTwo", mi.IntType()),
+        ),
+    )
+    assert mi.type_info(Example) == sol
+    assert mi.type_info(Example).fields[1].int_key is None
+
+
 def test_generic_struct():
     class Example(msgspec.Struct, Generic[T]):
         a: T

--- a/tests/unit/test_json.py
+++ b/tests/unit/test_json.py
@@ -2616,6 +2616,158 @@ class TestStruct:
             msgspec.json.decode(s, type=Test1)
 
 
+class TestStructIntKeys:
+    """JSON handling of structs configured with `int_keys`. Integer keys are
+    written as their decimal strings; decoding accepts that string or the
+    field's encoded name."""
+
+    def test_roundtrip_and_name_alias(self):
+        class Point(msgspec.Struct, int_keys={"x": 1, "y": 2}):
+            x: int
+            y: int
+
+        buf = msgspec.json.encode(Point(1, 2))
+        assert buf == b'{"1":1,"2":2}'
+        assert msgspec.json.decode(buf, type=Point) == Point(1, 2)
+        # The encoded field name is accepted as an alias when decoding
+        assert msgspec.json.decode(b'{"x":1,"2":2}', type=Point) == Point(1, 2)
+        assert msgspec.json.decode(b'{"x":1,"y":2}', type=Point) == Point(1, 2)
+
+    @pytest.mark.parametrize("key", [-(2**63), -1, 0, 1, 2**63 - 1])
+    def test_int64_boundaries_roundtrip(self, key):
+        class Test(msgspec.Struct, int_keys={"a": key}):
+            a: int
+
+        buf = msgspec.json.encode(Test(5))
+        assert buf == b'{"%d":5}' % key
+        assert msgspec.json.decode(buf, type=Test) == Test(5)
+
+    def test_min_int64_key_is_20_chars(self):
+        # `-9223372036854775808` is 20 characters; the sign must not eat into
+        # the digit budget.
+        class Test(msgspec.Struct, int_keys={"a": -(2**63)}):
+            a: int
+
+        key = b"-9223372036854775808"
+        assert len(key) == 20
+        assert msgspec.json.decode(b'{"' + key + b'":7}', type=Test) == Test(7)
+
+    @pytest.mark.parametrize(
+        "key",
+        [
+            "9223372036854775808",  # 2**63, one past the max
+            "-9223372036854775809",  # -2**63 - 1, one past the min
+            "18446744073709551615",  # 2**64 - 1
+            "18446744073709551616",  # 2**64, wraps a uint64 accumulator
+            "99999999999999999999",  # 20 digits
+            "-99999999999999999999",
+            "999999999999999999999999",  # far too long
+        ],
+    )
+    def test_out_of_range_key_never_matches_a_field(self, key):
+        # Both int64 extremes are mapped, so an overflowing parse that wrapped
+        # would land on one of them. It must instead be an unknown key.
+        class Test(msgspec.Struct, int_keys={"lo": -(2**63), "hi": 2**63 - 1}):
+            lo: int = 0
+            hi: int = 0
+
+        msg = ('{"%s": 99}' % key).encode()
+        assert msgspec.json.decode(msg, type=Test) == Test(0, 0)
+
+        Forbid = msgspec.defstruct(
+            "Forbid",
+            [("lo", int, 0), ("hi", int, 0)],
+            int_keys={"lo": -(2**63), "hi": 2**63 - 1},
+            forbid_unknown_fields=True,
+        )
+        with pytest.raises(msgspec.ValidationError, match="unknown field"):
+            msgspec.json.decode(msg, type=Forbid)
+
+    @pytest.mark.parametrize(
+        "key", ["01", "00", "-0", "-01", "+1", " 1", "1 ", "1.0", "1e0", "-", "", "０"]
+    )
+    def test_non_canonical_key_never_matches_a_field(self, key):
+        # Only the exact decimal string the encoder emits resolves to an int key
+        class Test(msgspec.Struct, int_keys={"a": 0, "b": 1}):
+            a: int = -1
+            b: int = -1
+
+        msg = ('{"%s": 99}' % key).encode()
+        assert msgspec.json.decode(msg, type=Test) == Test(-1, -1)
+
+    def test_unknown_int_key_skipped_or_forbidden(self):
+        class Test(msgspec.Struct, int_keys={"a": 1}):
+            a: int
+
+        assert msgspec.json.decode(b'{"1": 1, "2": 2}', type=Test) == Test(1)
+
+        Forbid = msgspec.defstruct(
+            "Forbid", [("a", int)], int_keys={"a": 1}, forbid_unknown_fields=True
+        )
+        with pytest.raises(msgspec.ValidationError, match="unknown field `2`"):
+            msgspec.json.decode(b'{"1": 1, "2": 2}', type=Forbid)
+
+    def test_partial_int_keys_and_rename(self):
+        class Test(msgspec.Struct, int_keys={"a": 1}, rename={"b": "bee"}):
+            a: int
+            b: int
+            c: int
+
+        buf = msgspec.json.encode(Test(1, 2, 3))
+        assert msgspec.json.decode(buf) == {"1": 1, "bee": 2, "c": 3}
+        assert msgspec.json.decode(buf, type=Test) == Test(1, 2, 3)
+        assert msgspec.json.decode(b'{"a":1,"bee":2,"c":3}', type=Test) == Test(
+            1, 2, 3
+        )
+
+    def test_same_field_name_and_int_key_spelling_allowed(self):
+        # A field whose *own* encoded name equals its int key's decimal string
+        # is unambiguous, and both spellings resolve to it.
+        class Test(msgspec.Struct, int_keys={"a": 1}, rename={"a": "1"}):
+            a: int
+
+        assert msgspec.json.encode(Test(3)) == b'{"1":3}'
+        assert msgspec.json.decode(b'{"1":3}', type=Test) == Test(3)
+
+    def test_tagged_union_roundtrip(self):
+        class A(msgspec.Struct, tag=True, int_keys={"x": 1}):
+            x: int
+
+        class B(msgspec.Struct, tag=True, int_keys={"x": 1, "y": 2}):
+            x: int
+            y: int
+
+        for obj in [A(1), B(1, 2)]:
+            buf = msgspec.json.encode(obj)
+            assert msgspec.json.decode(buf, type=Union[A, B]) == obj
+
+        # The tag may appear after the int keys
+        msg = b'{"1": 1, "2": 2, "type": "B"}'
+        assert msgspec.json.decode(msg, type=Union[A, B]) == B(1, 2)
+
+    def test_encoded_output_matches_schema(self):
+        class Test(msgspec.Struct, int_keys={"a": 1}, forbid_unknown_fields=True):
+            a: int
+            b: int = 0
+
+        schema = msgspec.json.schema(Test)["$defs"]["Test"]
+        msg = msgspec.json.decode(msgspec.json.encode(Test(10, 20)))
+        assert msg == {"1": 10, "b": 20}
+        assert set(schema["required"]) <= set(msg)
+        assert set(msg) <= set(schema["properties"])
+
+        jsonschema = pytest.importorskip("jsonschema")
+        full_schema = msgspec.json.schema(Test)
+        # The encoded form validates; the name alias `a` is not in the schema,
+        # so with `forbid_unknown_fields` it is rejected by the schema even
+        # though msgspec accepts it when decoding.
+        jsonschema.validate(msg, full_schema)
+        jsonschema.validate({"1": 10}, full_schema)
+        with pytest.raises(jsonschema.ValidationError):
+            jsonschema.validate({"a": 10}, full_schema)
+        assert msgspec.json.decode(b'{"a": 10}', type=Test) == Test(10)
+
+
 class TestStructUnion:
     """Most functionality is tested in `test_common.py:TestStructUnion`, this only
     checks for malformed inputs and whitespace handling"""

--- a/tests/unit/test_msgpack.py
+++ b/tests/unit/test_msgpack.py
@@ -1878,11 +1878,41 @@ class TestIntKeys:
         buf = msgspec.msgpack.encode({0: 1, "y": 2})
         assert msgspec.msgpack.decode(buf, type=IKInner) == IKInner(1, 2)
 
-    def test_json_uses_string_names(self):
+    def test_json_int_keys_string_coercion(self):
         obj = IKInner(1, 2)
         buf = msgspec.json.encode(obj)
-        assert buf == b'{"x":1,"y":2}'
+        # JSON object keys must be strings, so int_keys are coerced to their
+        # decimal string form ("0", "1"), mirroring integer dict keys.
+        assert buf == b'{"0":1,"1":2}'
         assert msgspec.json.decode(buf, type=IKInner) == obj
+        # Decode also accepts the original field names (name fallback), so a
+        # name-keyed producer or the `order='sorted'` output still round-trips.
+        assert msgspec.json.decode(b'{"x":1,"y":2}', type=IKInner) == obj
+
+    def test_json_int_keys_partial(self):
+        # a->0, c->2 are int-keyed; b keeps its name.
+        obj = IKPartial(a=1, b=2, c=3)
+        buf = msgspec.json.encode(obj)
+        assert msgspec.json.decode(buf) == {"0": 1, "b": 2, "2": 3}
+        assert msgspec.json.decode(buf, type=IKPartial) == obj
+
+    def test_json_int_keys_tagged_union(self):
+        # Tag stays a string key; int fields coerce to string keys; union decodes.
+        obj = IKTagged(1, 2)
+        buf = msgspec.json.encode(obj)
+        assert msgspec.json.decode(buf) == {"type": 123, "0": 1, "1": 2}
+        assert msgspec.json.decode(buf, type=IKTagged) == obj
+
+    def test_json_int_keys_sorted_emits_int_strings(self):
+        # order='sorted' emits the same int-string keys as the default JSON path
+        # (strict consistency), not field names.
+        buf = msgspec.json.Encoder(order="sorted").encode(IKInner(1, 2))
+        assert msgspec.json.decode(buf) == {"0": 1, "1": 2}
+        assert msgspec.json.decode(buf, type=IKInner) == IKInner(1, 2)
+        # tagged: the tag stays a string key, sorted after the int keys
+        tbuf = msgspec.json.Encoder(order="sorted").encode(IKTagged(1, 2))
+        assert msgspec.json.decode(tbuf) == {"0": 1, "1": 2, "type": 123}
+        assert msgspec.json.decode(tbuf, type=IKTagged) == IKTagged(1, 2)
 
     def test_int_tag_with_int_keys(self):
         obj = IKTagged(1, 2)
@@ -1950,6 +1980,35 @@ class TestIntKeys:
         # int-keyed fields sort (as ints) before string-keyed fields
         assert list(raw.items()) == [(1, 1), ("b", 2)]
         assert msgspec.msgpack.decode(enc.encode(P(1, 2)), type=P) == P(1, 2)
+
+    def test_tagged_union_decode_order_independent(self):
+        # An int-keyed tagged struct must decode as a union member regardless of
+        # where the (string) tag key falls on the wire. The sorted encoder orders
+        # int keys ahead of the tag, which previously broke the union tag-scan.
+        class A(msgspec.Struct, tag=True, int_keys={"a": 1, "b": 2}):
+            a: int
+            b: int
+
+        class B(msgspec.Struct, tag=True, int_keys={"a": 1}):
+            a: int
+
+        U = A | B
+        for enc in (msgspec.msgpack.Encoder(),
+                    msgspec.msgpack.Encoder(order="sorted")):
+            assert msgspec.msgpack.decode(enc.encode(A(1, 2)), type=U) == A(1, 2)
+            assert msgspec.msgpack.decode(enc.encode(B(9)), type=U) == B(9)
+
+    def test_tagged_union_decode_tag_last(self):
+        # Foreign-producer style: the tag is the LAST key, after the int keys.
+        class A(msgspec.Struct, tag=True, int_keys={"a": 1, "b": 2}):
+            a: int
+            b: int
+
+        class B(msgspec.Struct, tag=True, int_keys={"x": 1}):
+            x: int
+
+        wire = msgspec.msgpack.encode({1: 10, 2: 20, "type": "A"})
+        assert msgspec.msgpack.decode(wire, type=A | B) == A(10, 20)
 
 
 class TestStructArray:

--- a/tests/unit/test_msgpack.py
+++ b/tests/unit/test_msgpack.py
@@ -1800,6 +1800,158 @@ class TestStruct:
         assert res == Test()
 
 
+class IKInner(msgspec.Struct, int_keys={"x": 0, "y": 1}):
+    x: int
+    y: int
+
+
+class IKOuter(msgspec.Struct, int_keys={"inner": 0, "n": 1}):
+    inner: IKInner
+    n: int
+
+
+class IKPartial(msgspec.Struct, int_keys={"a": 0, "c": 2}):
+    a: int
+    b: int
+    c: int
+
+
+class IKDefaults(msgspec.Struct, int_keys={"a": 0, "b": 1}):
+    a: int
+    b: int = 42
+
+
+class IKTagged(msgspec.Struct, tag=123, int_keys={"a": 0, "b": 1}):
+    a: int
+    b: int
+
+
+class TestIntKeys:
+    def test_all_int_keys_roundtrip(self):
+        obj = IKInner(1, 2)
+        buf = msgspec.msgpack.encode(obj)
+        # Wire form uses integer keys
+        assert msgspec.msgpack.decode(buf) == {0: 1, 1: 2}
+        assert msgspec.msgpack.decode(buf, type=IKInner) == obj
+
+    def test_partial_map_roundtrip(self):
+        obj = IKPartial(1, 2, 3)
+        buf = msgspec.msgpack.encode(obj)
+        # a -> 0, c -> 2 are int; b stays a string key
+        assert msgspec.msgpack.decode(buf) == {0: 1, "b": 2, 2: 3}
+        assert msgspec.msgpack.decode(buf, type=IKPartial) == obj
+
+    def test_nested_int_keys_roundtrip(self):
+        obj = IKOuter(IKInner(1, 2), 3)
+        buf = msgspec.msgpack.encode(obj)
+        # Nested struct encodes with its own int keys automatically
+        assert msgspec.msgpack.decode(buf) == {0: {0: 1, 1: 2}, 1: 3}
+        assert msgspec.msgpack.decode(buf, type=IKOuter) == obj
+
+    def test_missing_key_uses_default(self):
+        # Only field `a` present -> `b` falls back to default
+        buf = msgspec.msgpack.encode({0: 5})
+        assert msgspec.msgpack.decode(buf, type=IKDefaults) == IKDefaults(5, 42)
+
+    def test_unknown_int_key_skipped(self):
+        # Int key 7 is unknown -> skipped
+        buf = msgspec.msgpack.encode({0: 1, 7: "junk", 1: 2})
+        assert msgspec.msgpack.decode(buf, type=IKInner) == IKInner(1, 2)
+
+    def test_unknown_int_key_forbidden(self):
+        Forbid = msgspec.defstruct(
+            "Forbid",
+            [("a", int), ("b", int)],
+            int_keys={"a": 0, "b": 1},
+            forbid_unknown_fields=True,
+        )
+        buf = msgspec.msgpack.encode({0: 1, 7: 2, 1: 3})
+        with pytest.raises(msgspec.ValidationError):
+            msgspec.msgpack.decode(buf, type=Forbid)
+
+    def test_string_keys_still_decode(self):
+        # An int-keyed struct still accepts string field names on decode
+        buf = msgspec.msgpack.encode({"x": 1, "y": 2})
+        assert msgspec.msgpack.decode(buf, type=IKInner) == IKInner(1, 2)
+
+        # Mixed int and string keys
+        buf = msgspec.msgpack.encode({0: 1, "y": 2})
+        assert msgspec.msgpack.decode(buf, type=IKInner) == IKInner(1, 2)
+
+    def test_json_uses_string_names(self):
+        obj = IKInner(1, 2)
+        buf = msgspec.json.encode(obj)
+        assert buf == b'{"x":1,"y":2}'
+        assert msgspec.json.decode(buf, type=IKInner) == obj
+
+    def test_int_tag_with_int_keys(self):
+        obj = IKTagged(1, 2)
+        buf = msgspec.msgpack.encode(obj)
+        # Tag key stays a string ("type"), fields use int keys
+        assert msgspec.msgpack.decode(buf) == {"type": 123, 0: 1, 1: 2}
+        assert msgspec.msgpack.decode(buf, type=IKTagged) == obj
+
+    def test_omit_defaults(self):
+        Omit = msgspec.defstruct(
+            "Omit",
+            [("a", int), ("b", int, 0)],
+            int_keys={"a": 0, "b": 1},
+            omit_defaults=True,
+        )
+        buf = msgspec.msgpack.encode(Omit(1, 0))
+        assert msgspec.msgpack.decode(buf) == {0: 1}
+        assert msgspec.msgpack.decode(buf, type=Omit) == Omit(1, 0)
+
+    def test_sorted_order_uses_int_keys(self):
+        class P(msgspec.Struct, int_keys={"a": 5, "b": 2, "c": 8}):
+            a: int
+            b: int
+            c: int
+
+        enc = msgspec.msgpack.Encoder(order="sorted")
+        raw = msgspec.msgpack.decode(enc.encode(P(1, 2, 3)))
+        # integer keys, emitted in ascending-id order (2, 5, 8) -- not strings
+        assert list(raw.items()) == [(2, 2), (5, 1), (8, 3)]
+        assert msgspec.msgpack.decode(enc.encode(P(1, 2, 3)), type=P) == P(1, 2, 3)
+
+    def test_deterministic_order_uses_int_keys(self):
+        class P(msgspec.Struct, int_keys={"x": 1, "y": 2}):
+            x: int
+            y: int
+
+        enc = msgspec.msgpack.Encoder(order="deterministic")
+        assert msgspec.msgpack.decode(enc.encode(P(1, 2))) == {1: 1, 2: 2}
+
+    def test_sorted_order_omit_defaults(self):
+        Omit = msgspec.defstruct(
+            "Omit", [("a", int), ("b", int, 0)],
+            int_keys={"a": 1, "b": 2}, omit_defaults=True,
+        )
+        enc = msgspec.msgpack.Encoder(order="sorted")
+        assert msgspec.msgpack.decode(enc.encode(Omit(5, 0))) == {1: 5}
+
+    def test_sorted_order_tagged(self):
+        class P(msgspec.Struct, tag=True, int_keys={"a": 1, "b": 2}):
+            a: int
+            b: int
+
+        enc = msgspec.msgpack.Encoder(order="sorted")
+        raw = msgspec.msgpack.decode(enc.encode(P(1, 2)))
+        assert raw == {"type": "P", 1: 1, 2: 2}      # tag stays a string key
+        assert msgspec.msgpack.decode(enc.encode(P(1, 2)), type=P) == P(1, 2)
+
+    def test_sorted_order_partial_map(self):
+        class P(msgspec.Struct, int_keys={"a": 1}):
+            a: int
+            b: int
+
+        enc = msgspec.msgpack.Encoder(order="sorted")
+        raw = msgspec.msgpack.decode(enc.encode(P(1, 2)))
+        # int-keyed fields sort (as ints) before string-keyed fields
+        assert list(raw.items()) == [(1, 1), ("b", 2)]
+        assert msgspec.msgpack.decode(enc.encode(P(1, 2)), type=P) == P(1, 2)
+
+
 class TestStructArray:
     @pytest.mark.parametrize("tag", [False, "Test", 123])
     def test_encode_empty_struct(self, tag):

--- a/tests/unit/test_schema.py
+++ b/tests/unit/test_schema.py
@@ -450,6 +450,60 @@ def test_struct_object_tagged():
     }
 
 
+def test_struct_object_int_keys():
+    class Point(msgspec.Struct, int_keys={"x": 1, "y": 2}, rename={"z": "zed"}):
+        """An example docstring"""
+
+        x: int
+        y: int = 0
+        z: int = 0
+
+    # The schema describes the wire form: int-keyed fields appear under the
+    # decimal string of their key, not their field name (which is only
+    # accepted as a decoding alias). Other fields keep their encoded name.
+    assert msgspec.json.schema(Point) == {
+        "$ref": "#/$defs/Point",
+        "$defs": {
+            "Point": {
+                "title": "Point",
+                "description": "An example docstring",
+                "type": "object",
+                "properties": {
+                    "1": {"type": "integer"},
+                    "2": {"type": "integer", "default": 0},
+                    "zed": {"type": "integer", "default": 0},
+                },
+                "required": ["1"],
+            }
+        },
+    }
+    # Encoded output uses exactly the keys the schema declares
+    msg = msgspec.json.decode(msgspec.json.encode(Point(1, 2, 3)))
+    assert msg == {"1": 1, "2": 2, "zed": 3}
+
+
+def test_struct_object_int_keys_tagged():
+    class Point(msgspec.Struct, tag=True, int_keys={"x": 1, "y": 2}):
+        x: int
+        y: int
+
+    assert msgspec.json.schema(Point) == {
+        "$ref": "#/$defs/Point",
+        "$defs": {
+            "Point": {
+                "title": "Point",
+                "type": "object",
+                "properties": {
+                    "type": {"enum": ["Point"]},
+                    "1": {"type": "integer"},
+                    "2": {"type": "integer"},
+                },
+                "required": ["type", "1", "2"],
+            }
+        },
+    }
+
+
 def test_struct_array_tagged():
     class Point(msgspec.Struct, tag=True, array_like=True):
         x: int

--- a/tests/unit/test_struct.py
+++ b/tests/unit/test_struct.py
@@ -2117,6 +2117,102 @@ class TestRename:
             Test(one=1)
 
 
+class TestIntKeys:
+    def test_int_keys_basic(self):
+        class Test(Struct, int_keys={"a": 0, "b": 1}):
+            a: int
+            b: int
+
+        assert Test.__struct_fields__ == ("a", "b")
+        # int_keys does not affect the string encode fields
+        assert Test.__struct_encode_fields__ == ("a", "b")
+
+    def test_int_keys_value_out_of_range(self):
+        with pytest.raises(ValueError, match=r"\[-2\*\*63, 2\*\*63 - 1\]"):
+
+            class Test(Struct, int_keys={"a": 2**63}):
+                a: int
+
+    def test_int_keys_value_not_int(self):
+        with pytest.raises(TypeError, match="int_keys"):
+
+            class Test(Struct, int_keys={"a": "nope"}):
+                a: int
+
+    def test_int_keys_duplicate_value(self):
+        with pytest.raises(ValueError, match="unique"):
+
+            class Test(Struct, int_keys={"a": 0, "b": 0}):
+                a: int
+                b: int
+
+    def test_int_keys_unknown_field(self):
+        with pytest.raises(ValueError, match="does not exist"):
+
+            class Test(Struct, int_keys={"nope": 0}):
+                a: int
+
+    def test_int_keys_negative_ok(self):
+        class Test(Struct, int_keys={"a": -1}):
+            a: int
+
+        buf = msgspec.msgpack.encode(Test(5))
+        assert msgspec.msgpack.decode(buf) == {-1: 5}
+        assert msgspec.msgpack.decode(buf, type=Test) == Test(5)
+
+    def test_int_keys_inheritance(self):
+        class Base(Struct, int_keys={"a": 0}):
+            a: int
+
+        class Child(Base, int_keys={"b": 1}):
+            b: int
+
+        # Child merges base + own int_keys
+        buf = msgspec.msgpack.encode(Child(1, 2))
+        assert msgspec.msgpack.decode(buf) == {0: 1, 1: 2}
+        assert msgspec.msgpack.decode(buf, type=Child) == Child(1, 2)
+
+    def test_int_keys_inheritance_override(self):
+        class Base(Struct, int_keys={"a": 0}):
+            a: int
+
+        class Child(Base, int_keys={"a": 5}):
+            a: int
+
+        buf = msgspec.msgpack.encode(Child(9))
+        assert msgspec.msgpack.decode(buf) == {5: 9}
+
+    def test_int_keys_defstruct(self):
+        Test = defstruct("Test", ["a", "b"], int_keys={"a": 0, "b": 1})
+        buf = msgspec.msgpack.encode(Test(1, 2))
+        assert msgspec.msgpack.decode(buf) == {0: 1, 1: 2}
+        assert msgspec.msgpack.decode(buf, type=Test) == Test(1, 2)
+
+    def test_int_keys_introspection_via_fields(self):
+        import msgspec.structs
+
+        class Test(msgspec.Struct, int_keys={"a": 0, "b": 5}, rename={"c": "cee"}):
+            a: int
+            b: int
+            c: str = "z"
+
+        by_name = {f.name: f for f in msgspec.structs.fields(Test)}
+        assert by_name["a"].int_key == 0
+        assert by_name["b"].int_key == 5
+        assert by_name["c"].int_key is None          # str-renamed, not int-keyed
+        assert by_name["c"].encode_name == "cee"
+        assert Test.__struct_encode_int_keys__ == (0, 5, None)
+
+    def test_int_keys_introspection_absent(self):
+        import msgspec.structs
+
+        class Plain(msgspec.Struct):
+            x: int
+
+        assert Plain.__struct_encode_int_keys__ is None
+        assert msgspec.structs.fields(Plain)[0].int_key is None
+
+
 class TestDefStruct:
     def test_defstruct_simple(self):
         Point = defstruct("Point", ["x", "y"])

--- a/tests/unit/test_struct.py
+++ b/tests/unit/test_struct.py
@@ -2212,6 +2212,16 @@ class TestIntKeys:
         assert Plain.__struct_encode_int_keys__ is None
         assert msgspec.structs.fields(Plain)[0].int_key is None
 
+    def test_int_keys_array_like_rejected(self):
+        # array_like drops field keys entirely, so int_keys would be a silent
+        # no-op -- reject the combination at class creation instead.
+        with pytest.raises(ValueError, match="array_like"):
+            class P(msgspec.Struct, array_like=True, int_keys={"a": 1}):
+                a: int
+
+        with pytest.raises(ValueError, match="array_like"):
+            msgspec.defstruct("Q", [("a", int)], array_like=True, int_keys={"a": 1})
+
 
 class TestDefStruct:
     def test_defstruct_simple(self):

--- a/tests/unit/test_struct.py
+++ b/tests/unit/test_struct.py
@@ -2222,6 +2222,88 @@ class TestIntKeys:
         with pytest.raises(ValueError, match="array_like"):
             msgspec.defstruct("Q", [("a", int)], array_like=True, int_keys={"a": 1})
 
+    @pytest.mark.parametrize("key", [-(2**63), 2**63 - 1])
+    def test_int_keys_int64_boundaries_accepted(self, key):
+        class Test(Struct, int_keys={"a": key}):
+            a: int
+
+        assert Test.__struct_encode_int_keys__ == (key,)
+
+    @pytest.mark.parametrize("key", [-(2**63) - 1, 2**63, 2**64])
+    def test_int_keys_value_outside_int64_rejected(self, key):
+        with pytest.raises(ValueError, match=r"\[-2\*\*63, 2\*\*63 - 1\]"):
+
+            class Test(Struct, int_keys={"a": key}):
+                a: int
+
+    def test_int_keys_conflict_with_renamed_field(self):
+        # In JSON the int key 1 is written as "1", the same key as field `b`
+        with pytest.raises(ValueError, match="conflicts with field 'b'"):
+
+            class Test(Struct, int_keys={"a": 1}, rename={"b": "1"}):
+                a: int
+                b: int = 0
+
+    def test_int_keys_conflict_with_field_named_like_int(self):
+        with pytest.raises(ValueError, match="conflicts with field"):
+            defstruct("Test", [("a", int), ("1", int)], int_keys={"a": 1})
+
+    def test_int_keys_conflict_with_renamed_field_via_rename_callable(self):
+        with pytest.raises(ValueError, match="conflicts with field 'b'"):
+
+            class Test(
+                Struct,
+                int_keys={"a": -5},
+                rename=lambda n: "-5" if n == "b" else None,
+            ):
+                a: int
+                b: int
+
+    def test_int_keys_conflict_with_field_name_in_subclass(self):
+        class Base(Struct, int_keys={"a": 1}):
+            a: int
+
+        with pytest.raises(ValueError, match="conflicts with field 'b'"):
+
+            class Child(Base, rename={"b": "1"}):
+                b: int
+
+    def test_int_keys_same_field_name_and_key_spelling_allowed(self):
+        # Both spellings name the same field, so there's no ambiguity
+        class Test(Struct, int_keys={"a": 1}, rename={"a": "1"}):
+            a: int
+
+        assert Test.__struct_encode_fields__ == ("1",)
+        assert Test.__struct_encode_int_keys__ == (1,)
+
+    def test_int_keys_conflict_with_tag_field(self):
+        with pytest.raises(
+            ValueError, match="tag_field='1' conflicts with the `int_keys` value 1"
+        ):
+
+            class Test(Struct, tag=True, tag_field="1", int_keys={"a": 1}):
+                a: int
+
+        with pytest.raises(ValueError, match="tag_field='-2' conflicts"):
+            defstruct("Test", [("a", int)], tag="t", tag_field="-2", int_keys={"a": -2})
+
+    def test_int_keys_tag_field_conflict_inherited(self):
+        class Base(Struct, tag=True, tag_field="1"):
+            pass
+
+        with pytest.raises(ValueError, match="tag_field='1' conflicts"):
+
+            class Child(Base, int_keys={"a": 1}):
+                a: int
+
+    def test_int_keys_no_conflict_when_untagged(self):
+        # `tag_field` is ignored (and so can't conflict) when `tag=False`
+        class Test(Struct, tag=False, tag_field="1", int_keys={"a": 1}):
+            a: int
+
+        assert Test.__struct_config__.tag_field is None
+        assert msgspec.json.encode(Test(5)) == b'{"1":5}'
+
 
 class TestDefStruct:
     def test_defstruct_simple(self):


### PR DESCRIPTION
Add `int_keys`: integer MessagePack map keys for Structs

## Motivation

There's an inherent tension between having descriptive field names on a Struct and
the size of its encoded representation — every field name is repeated, in full, in
every message. Since one of msgspec's biggest draws is its encoding efficiency,
being able to encode a Struct's fields with integer keys instead of their names is
an attractive way to shrink MessagePack messages further.

`rename` to single-character names helps, and is the right tool when you need a
readable/valid JSON representation. But MessagePack can do better: it supports
integer map keys directly, and even in JavaScript the common MessagePack decoders
handle integer keys gracefully. This PR makes that available.

## What this adds

A new Struct configuration option, `int_keys`, mapping field names to integers:

```python
class Point(msgspec.Struct, int_keys={"x": 1, "y": 2}):
    x: int
    y: int

>>> msgspec.msgpack.decode(msgspec.msgpack.encode(Point(1, 2)))
{1: 1, 2: 2}
>>> msgspec.msgpack.decode(msgspec.msgpack.encode(Point(1, 2)), type=Point)
Point(x=1, y=2)
```

## Design

- **MessagePack-only.** JSON object keys must be strings, so the JSON encoder
  ignores `int_keys` and keeps using the (possibly renamed) field names — no error,
  and the existing fast JSON path is untouched.
- **A dedicated option, not an extension of `rename`.** `rename` is string-valued
  and applies to both codecs; keeping `int_keys` separate avoids overloading its
  meaning, and the two compose cleanly (a field can be renamed for JSON *and*
  int-keyed for MessagePack).
- **Reuses existing machinery.** Encoding integer keys uses `mpack_encode_long`;
  decoding uses the same `IntLookup` reverse-lookup that already backs integer
  union tags — so this leans on well-trodden code paths rather than introducing new
  ones.
- **Minimal overhead when unused.** The two new `StructMetaObject` members are `NULL`
  for Structs without `int_keys`, and the encode/decode fast paths are unchanged for
  them. On decode, the key type is only inspected for Structs that opt in.
- **Baked onto the type.** Nested Structs are handled automatically — each encodes
  with its own keys, with nothing extra required at encode/decode time. Partial maps
  are allowed (unlisted fields keep their string keys); keys must be unique within a
  Struct and fit in a signed 64-bit integer.
- **Introspectable.** The assigned key is exposed via
  `msgspec.structs.fields(...).int_key`.

## Compatibility, tests, docs

Fully backward compatible — no behavior change for Structs that don't use
`int_keys`. Includes tests (`tests/unit/test_msgpack.py`, `tests/unit/test_struct.py`)
and documentation (`docs/structs.rst`).

Please consider this addition to msgspec — I'm eager to discuss any amendments or
adjustments that would help it fit the project.
