### PR TITLE
Fix minItems for all-optional array-like Structs

### DIFF
--- a/src/msgspec/_json_schema.py
+++ b/src/msgspec/_json_schema.py
@@ -411,9 +411,10 @@ class _SchemaGenerator:
 
             if t.array_like:
                 n_trailing_defaults = 0
-                for n_trailing_defaults, f in enumerate(reversed(t.fields)):
+                for f in reversed(t.fields):
                     if f.required:
                         break
+                    n_trailing_defaults += 1
                 schema["type"] = "array"
                 schema["prefixItems"] = fields
                 schema["minItems"] = len(fields) - n_trailing_defaults

--- a/tests/unit/test_schema.py
+++ b/tests/unit/test_schema.py
@@ -411,6 +411,20 @@ def test_struct_array_like(forbid_unknown_fields):
     assert msgspec.json.schema(Example) == sol
 
 
+@pytest.mark.parametrize(
+    "tag, min_items, payload",
+    [(False, 0, b"[]"), (True, 1, b'["Example"]')],
+)
+def test_struct_array_like_all_fields_optional(tag, min_items, payload):
+    class Example(msgspec.Struct, array_like=True, tag=tag):
+        a: int = 1
+        b: list[int] = msgspec.field(default_factory=list)
+
+    schema = msgspec.json.schema(Example)["$defs"]["Example"]
+    assert msgspec.json.decode(payload, type=Example) == Example()
+    assert schema["minItems"] == min_items
+
+
 def test_struct_no_fields():
     class Example(msgspec.Struct):
         pass


### PR DESCRIPTION
## Problem

For an `array_like=True` Struct where every user field has a default, `msgspec.json.schema` reports `minItems` one too high. An untagged Struct gets `minItems: 1` even though `msgspec.json.decode` accepts `[]` and fills all defaults; a tagged Struct similarly gets 2 even though a tag-only array is valid. Generated schemas therefore reject payloads accepted by msgspec itself.

The trailing-default loop stored the zero-based `enumerate` index and later used it as a count. When the loop never encountered a required field, that count was one short.

## Fix

Count trailing optional fields explicitly before calculating `minItems`. The existing required-field and empty-Struct boundaries remain unchanged.

The regression test covers both tagged and untagged Structs and includes a `default_factory`, while checking the generated schema against the public decoder contract.

## Testing

- `just test tests/unit/test_schema.py` — 124 passed, 2 skipped
- `just test` — 6412 passed, 113 skipped
- `just check` — lint, format, and spelling checks passed