### PR TITLE
Fixed an issue decoding `Dataclass` and `TypedDict` instances

### DIFF
--- a/src/msgspec/_core.c
+++ b/src/msgspec/_core.c
@@ -8734,6 +8734,9 @@ TypedDictInfo_Convert(PyObject *obj) {
         Py_INCREF(key);
         info->fields[i].key = key;
         info->fields[i].type = type;
+        /* Prime the UTF8 cache so later unicode_str_and_length_nocheck can be
+        * safely used (it assumes the UTF8 is cached) */
+        if (PyUnicode_AsUTF8(key) == NULL) goto cleanup;
         int contains = PySet_Contains(required, key);
         if (contains == -1) goto cleanup;
         if (contains) { type->types |= MS_EXTRA_FLAG; }
@@ -8926,6 +8929,9 @@ DataclassInfo_Convert(PyObject *obj) {
         info->fields[i].type = type;
         info->fields[i].key = PyTuple_GET_ITEM(field, 0);
         Py_INCREF(info->fields[i].key);
+        /* Prime the UTF8 cache so later unicode_str_and_length_nocheck can be
+	* safely used (it assumes the UTF8 is cached) */
+        if (PyUnicode_AsUTF8(info->fields[i].key) == NULL) goto cleanup;
     }
 
     PyObject_GC_Track(info);

--- a/tests/unit/test_json.py
+++ b/tests/unit/test_json.py
@@ -2013,6 +2013,43 @@ class TestDict:
         ids = {id(k) for d in res for k in d.keys()}
         assert len(ids) == 3
 
+    @pytest.mark.skipif(
+        hasattr(sys.flags, "gil") and not sys.flags.gil,
+        reason="cache is disabled without GIL",
+    )
+    def test_decode_dataclass_utf8_keys_cache(self):
+        """Non-ascii dataclass field names decode correctly with a fresh cache"""
+
+        @dataclass
+        class Foo:
+            π: float
+            μ: int
+
+        for _ in range(10):
+            gc.collect()  # cache is cleared every 10 full collections
+
+        foo = msgspec.json.decode(b'{"\xcf\x80":3.14,"\xce\xbc":0}', type=Foo)
+        assert foo.π == 3.14
+        assert foo.μ == 0
+
+    @pytest.mark.skipif(
+        hasattr(sys.flags, "gil") and not sys.flags.gil,
+        reason="cache is disabled without GIL",
+    )
+    def test_decode_typeddict_utf8_keys_cache(self):
+        """Non-ascii TypedDict field names decode correctly with a fresh cache"""
+
+        class Foo(TypedDict):
+            π: float
+            μ: int
+
+        for _ in range(10):
+            gc.collect()  # cache is cleared every 10 full collections
+
+        foo = msgspec.json.decode(b'{"\xcf\x80":3.14,"\xce\xbc":0}', type=Foo)
+        assert foo["π"] == 3.14
+        assert foo["μ"] == 0
+
     @pytest.mark.parametrize(
         "key",
         [


### PR DESCRIPTION
To reproduce try this snippet (in a fresh process):

```python
from dataclasses import dataclass
import msgspec

@dataclass
class Foo:
    π: float
    μ: int

foo = msgspec.json.decode(b'{"\xcf\x80":3.14,"\xce\xbc":0}', type=Foo)
print(foo)
```
Can't decode π because it is unicode and hasn't been loaded into the unicode cache yet

But this:
```python
from dataclasses import dataclass
import msgspec

@dataclass
class Foo:
    π: float
    μ: int

print(msgspec.json.encode(Foo(3.1416, 1)))
foo = msgspec.json.decode(b'{"\xcf\x80":3.14,"\xce\xbc":0}', type=Foo)
print(foo)
```
works fine since the cache is populated during encoding.
This PR should have a fix for this and also a test that fails the old unfixed version.