### PR TITLE
fix: raise ValidationError for out-of-range int→float in convert

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -4,7 +4,7 @@
 
 - Fix `msgspec.convert` raising `SystemError` when converting an out-of-range
   `int` to `float`; it now raises `ValidationError` like `json.decode`
-  ({issue}`1122`).
+  ({issue}`1122`, {pr}`1128`).
 - Add `frozendict` support on Python 3.15+ ({pr}`1052`, {pr}`1105`).
 - Support passing a callable as `decimal_format` to `msgspec.json.Encoder` and
   `msgspec.msgpack.Encoder` for custom `Decimal` encoding ({pr}`978`).

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+- Fix `msgspec.convert` raising `SystemError` when converting an out-of-range
+  `int` to `float`; it now raises `ValidationError` like `json.decode`
+  ({issue}`1122`).
 - Add `frozendict` support on Python 3.15+ ({pr}`1052`, {pr}`1105`).
 - Support passing a callable as `decimal_format` to `msgspec.json.Encoder` and
   `msgspec.msgpack.Encoder` for custom `Decimal` encoding ({pr}`978`).

--- a/src/msgspec/_core.c
+++ b/src/msgspec/_core.c
@@ -20937,7 +20937,18 @@ convert_int(
         return ms_decode_int_enum_or_literal_pyint(obj, type, path);
     }
     else if (type->types & MS_TYPE_FLOAT) {
-        return ms_decode_float(PyLong_AsDouble(obj), type, path);
+        double x = PyLong_AsDouble(obj);
+        /* PyLong_AsDouble sets OverflowError and may return ±inf for ints that
+         * cannot be represented as a finite C double. Surface that as a
+         * ValidationError (matching json.decode) instead of leaking SystemError. */
+        if (x == -1.0 && PyErr_Occurred()) {
+            PyErr_Clear();
+            return ms_error_with_path("Number out of range%U", path);
+        }
+        if (MS_UNLIKELY(!isfinite(x))) {
+            return ms_error_with_path("Number out of range%U", path);
+        }
+        return ms_decode_float(x, type, path);
     }
     else if (
         type->types & MS_TYPE_DECIMAL

--- a/tests/unit/test_convert.py
+++ b/tests/unit/test_convert.py
@@ -429,6 +429,17 @@ class TestFloat:
         with pytest.raises(ValidationError, match="Expected `float`, got `null`"):
             convert(None, float)
 
+    def test_float_from_out_of_range_int(self):
+        # ints that overflow a C double must raise ValidationError (like json.decode),
+        # not leak SystemError from PyLong_AsDouble.
+        big = 10**400
+        with pytest.raises(ValidationError, match="Number out of range"):
+            convert(big, float)
+        with pytest.raises(ValidationError, match="Number out of range"):
+            convert({"v": big}, dict[str, float])
+        with pytest.raises(ValidationError, match="Number out of range"):
+            convert(-big, float)
+
     @pytest.mark.parametrize(
         "meta, good, bad",
         [


### PR DESCRIPTION
## Summary

Fixes #1122.

`msgspec.convert(10**400, float)` was leaking `SystemError` because `PyLong_AsDouble` sets `OverflowError` while `convert` still returned a float object. `json.decode` already reports this as `ValidationError: Number out of range`.

Clear the overflow error and raise `ValidationError` (same message as the JSON path). Also reject non-finite results as a belt-and-suspenders check.

## Test plan

- [x] `pytest tests/unit/test_convert.py::TestFloat::test_float_from_out_of_range_int tests/unit/test_convert.py::TestFloat::test_float`
- [ ] CI


Made with [Cursor](https://cursor.com)