### PR TITLE
Fix overriding an inherited field alias back to the field's own name

### DIFF
--- a/src/msgspec/_core.c
+++ b/src/msgspec/_core.c
@@ -5908,7 +5908,12 @@ structmeta_process_rename(
         ((Field *)default_value)->name != NULL
     ) {
         Field *field = (Field *)default_value;
-        if (PyUnicode_Compare(name, field->name) == 0) return 0;
+        if (PyUnicode_Compare(name, field->name) == 0) {
+            if (PyDict_GetItem(info->renamed_fields, name) != NULL) {
+                return PyDict_DelItem(info->renamed_fields, name);
+            }
+            return 0;
+        }
         return PyDict_SetItem(info->renamed_fields, name, field->name);
     }
 
@@ -5952,6 +5957,9 @@ structmeta_process_rename(
     int out = 0;
     if (PyUnicode_Compare(name, temp) != 0) {
         out = PyDict_SetItem(info->renamed_fields, name, temp);
+    }
+    else if (PyDict_GetItem(info->renamed_fields, name) != NULL) {
+        out = PyDict_DelItem(info->renamed_fields, name);
     }
     Py_DECREF(temp);
     return out;

--- a/tests/unit/test_struct.py
+++ b/tests/unit/test_struct.py
@@ -2102,6 +2102,29 @@ class TestRename:
 
         assert Test4.__struct_encode_fields__ == ("my_field",)
 
+    def test_field_name_override_inherited(self):
+        class Base(Struct):
+            x: int = field(name="_x")
+
+        class Test1(Base):
+            x: int = field(name="x")
+
+        assert Test1.__struct_encode_fields__ == ("x",)
+
+        class Test2(Base):
+            x: int = 1
+
+        assert Test2.__struct_encode_fields__ == ("_x",)
+
+    def test_rename_override_inherited(self):
+        class Base(Struct, rename="upper"):
+            x: int
+
+        class Test(Base, rename="lower"):
+            x: int
+
+        assert Test.__struct_encode_fields__ == ("x",)
+
     def test_rename_fields_only_used_for_encode_and_decode(self):
         """Check that the renamed fields don't show up elsewhere"""
 


### PR DESCRIPTION
Fixes #654.

`structmeta_process_rename` skips writing to `renamed_fields` when the requested encode name equals the field's own name, leaving any alias inherited from a base class in place. So `field(name="x")` on a redeclared field `x` was silently ignored, and the same held for a `rename=` policy whose result is the field's own name (e.g. `rename="lower"` under a parent's `rename="upper"`):

```python
class Base(Struct):
    x: int = field(name="_x")

class Sub(Base):
    x: int = field(name="x")

Sub.__struct_encode_fields__  # ('_x',), expected ('x',)
```

The fix clears the inherited entry at both sites instead of skipping the write. Redeclared fields already re-apply the effective naming config, including overriding a base's `field(name=...)` alias with a policy result; this extends that to identity results.

Two behaviors deliberately unchanged: a redeclaration expressing no naming intent (`x: int = 1`, no policy in effect) keeps the inherited alias, and so does `rename=None`, which acts as "no policy in this class" rather than an identity policy. Clearing per field is spelled `field(name="x")`. Both new tests fail before the fix.
