### PR TITLE
src/msgspec/_core.c: Fix backing type declaration of Ext.code

### DIFF
--- a/src/msgspec/_core.c
+++ b/src/msgspec/_core.c
@@ -9315,7 +9315,7 @@ Ext_dealloc(Ext *self)
 }
 
 static PyMemberDef Ext_members[] = {
-    {"code", T_INT, offsetof(Ext, code), READONLY, "The extension type code"},
+    {"code", T_LONG, offsetof(Ext, code), READONLY, "The extension type code"},
     {"data", T_OBJECT_EX, offsetof(Ext, data), READONLY, "The extension data payload"},
     {NULL},
 };


### PR DESCRIPTION
Fixes the TestExt test suite on big-endian systems.

`(Ext).code` is implemented by a `long` in the C code, but declared to be backed by an `int` for access from Python. Correct this.

When `long` is larger than `int`, the previous declaration caused only an endian-specific part of the `code` value to get returned when read from Python-land. On little-endian it was the lower half, and with the valid range of `code` values being small enough to fit in 1 byte, everything seemed fine.

On big-endian, this returned the upper half of the `long` instead, so all `assert`s of `(Ext).code` values failed because the only possible values were 0 and -1.

---

Example output of the tests on a big-endian machine (powerpc64-linux) before this change:

```
=========================== short test summary info ============================
FAILED tests/unit/test_msgpack.py::TestExt::test_init[test] - assert 0 == 1
FAILED tests/unit/test_msgpack.py::TestExt::test_init[data1] - assert 0 == 1
FAILED tests/unit/test_msgpack.py::TestExt::test_init[data2] - assert 0 == 1
FAILED tests/unit/test_msgpack.py::TestExt::test_code_roundtrip[-128] - assert -1 == -128
FAILED tests/unit/test_msgpack.py::TestExt::test_code_roundtrip[-2] - assert -1 == -2
FAILED tests/unit/test_msgpack.py::TestExt::test_code_roundtrip[2] - assert 0 == 2
FAILED tests/unit/test_msgpack.py::TestExt::test_code_roundtrip[127] - assert 0 == 127
FAILED tests/unit/test_msgpack.py::TestExt::test_pickleable - assert 0 == 1
FAILED tests/unit/test_msgpack.py::TestExt::test_roundtrip[0] - assert 0 == 5
FAILED tests/unit/test_msgpack.py::TestExt::test_roundtrip[1] - assert 0 == 5
FAILED tests/unit/test_msgpack.py::TestExt::test_roundtrip[2] - assert 0 == 5
FAILED tests/unit/test_msgpack.py::TestExt::test_roundtrip[4] - assert 0 == 5
FAILED tests/unit/test_msgpack.py::TestExt::test_roundtrip[8] - assert 0 == 5
FAILED tests/unit/test_msgpack.py::TestExt::test_roundtrip[16] - assert 0 == 5
FAILED tests/unit/test_msgpack.py::TestExt::test_roundtrip[31] - assert 0 == 5
FAILED tests/unit/test_msgpack.py::TestExt::test_roundtrip[32] - assert 0 == 5
FAILED tests/unit/test_msgpack.py::TestExt::test_roundtrip[255] - assert 0 == 5
FAILED tests/unit/test_msgpack.py::TestExt::test_roundtrip[256] - assert 0 == 5
FAILED tests/unit/test_msgpack.py::TestExt::test_roundtrip[65535] - assert 0 == 5
FAILED tests/unit/test_msgpack.py::TestExt::test_roundtrip[65536] - assert 0 == 5
=========== 20 failed, 5798 passed, 379 skipped in 74.33s (0:01:14) ============
```