### PR TITLE
Build CPython 3.15 wheels

### DIFF
--- a/.cibuildwheel.toml
+++ b/.cibuildwheel.toml
@@ -1,5 +1,5 @@
 [tool.cibuildwheel]
-build = "cp310-* cp311-* cp312-* cp313-* cp314-* cp314t-*"
+build = "cp310-* cp311-* cp312-* cp313-* cp314-* cp314t-* cp315-* cp315t*"
 build-frontend = "build[uv]"
 test-command = "pytest {project}/tests/unit"
 test-groups = ["test-unit"]


### PR DESCRIPTION
https://github.com/msgspec/msgspec/pull/1146 bumped cibuildwheel to 4.2.0, which adds CPython 3.15 wheels by default, but this project uses a build list in `.cibuildwheel.toml` so they need to be selected explicitly.
