### PR TITLE
Add narrow Struct builder C API

### DIFF
--- a/.justfile
+++ b/.justfile
@@ -268,6 +268,16 @@ _with_env env action *args:
       } \
     } \
   }}{{ \
+    if env == "test" { \
+      if os() == "windows" { \
+        "$env:MSGSPEC_COMPILE_TEST_CAPI='1'; " \
+      } else { \
+        "MSGSPEC_COMPILE_TEST_CAPI=1 " \
+      } \
+    } else { \
+      "" \
+    } \
+  }}{{ \
     if debug =~ "^(true|1)$" { \
       if os() == "windows" { \
         "$env:MSGSPEC_DEBUG='1'; " \

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -7,3 +7,5 @@ prune scripts
 exclude lychee.toml
 exclude .*
 include .cibuildwheel.toml
+include src/msgspec/msgspec.h
+include src/msgspec/_testcapi.c

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -121,7 +121,11 @@ packages = ["msgspec"]
 [tool.setuptools.exclude-package-data]
 msgspec = [
   "*.c",
-  "*.h",
+  "atof.h",
+  "atof_consts.h",
+  "common.h",
+  "itoa.h",
+  "ryu.h",
 ]
 
 [tool.setuptools_scm]

--- a/setup.py
+++ b/setup.py
@@ -26,6 +26,7 @@ if sys.platform == "win32" and sys.maxsize == (2**31 - 1):
 SANITIZE = os.environ.get("MSGSPEC_SANITIZE", False)
 COVERAGE = os.environ.get("MSGSPEC_COVERAGE", False)
 DEBUG = os.environ.get("MSGSPEC_DEBUG", SANITIZE or COVERAGE)
+TEST_CAPI = os.environ.get("MSGSPEC_COMPILE_TEST_CAPI", False)
 
 extra_compile_args = []
 extra_link_args = []
@@ -65,6 +66,16 @@ ext_modules = [
         extra_link_args=extra_link_args,
     )
 ]
+
+if TEST_CAPI:
+    ext_modules.append(
+        Extension(
+            "msgspec._testcapi",
+            [os.path.join("src", "msgspec", "_testcapi.c")],
+            extra_compile_args=extra_compile_args,
+            extra_link_args=extra_link_args,
+        )
+    )
 
 setup(
     ext_modules=ext_modules,

--- a/src/msgspec/_core.c
+++ b/src/msgspec/_core.c
@@ -15,6 +15,7 @@
 #include "itoa.h"
 #include "ryu.h"
 #include "atof.h"
+#include "msgspec.h"
 
 /* Python version checks */
 #define PY311_PLUS (PY_VERSION_HEX >= 0x030b0000)
@@ -7526,6 +7527,214 @@ PyDoc_STRVAR(StructMeta__doc__,
 ">>> Example(b=123)\n"
 "Example(a='', b=123)\n"
 );
+
+
+/*************************************************************************
+ * Narrow native Struct-construction C API                               *
+ *************************************************************************/
+
+/* Forward declarations for helpers defined below this API block. */
+static PyObject *get_default(PyObject *obj);
+static MS_INLINE int Struct_post_init(StructMetaObject *st_type, PyObject *obj);
+static MS_NOINLINE void Struct_build_abstract_error(PyTypeObject *cls);
+
+/*
+ * Opaque producer-owned builder token. Consumers receive only PyObject*,
+ * never this layout. The token participates in cyclic GC because a Struct
+ * class can retain arbitrary objects that retain the token in turn.
+ */
+typedef struct {
+    PyObject_HEAD
+    PyTypeObject *cls;
+    StructMetaObject *st_type;
+    Py_ssize_t nfields;
+} StructBuilderObject;
+
+static int
+StructBuilder_traverse(StructBuilderObject *self, visitproc visit, void *arg)
+{
+    Py_VISIT(self->cls);
+    return 0;
+}
+
+static int
+StructBuilder_clear(StructBuilderObject *self)
+{
+    Py_CLEAR(self->cls);
+    self->st_type = NULL;
+    self->nfields = 0;
+    return 0;
+}
+
+static void
+StructBuilder_dealloc(StructBuilderObject *self)
+{
+    PyObject_GC_UnTrack(self);
+    StructBuilder_clear(self);
+    Py_TYPE(self)->tp_free((PyObject *)self);
+}
+
+static PyTypeObject StructBuilder_Type = {
+    PyVarObject_HEAD_INIT(NULL, 0)
+    .tp_name = "msgspec._core._StructBuilder",
+    .tp_basicsize = sizeof(StructBuilderObject),
+    .tp_flags = Py_TPFLAGS_DEFAULT | Py_TPFLAGS_HAVE_GC,
+    .tp_dealloc = (destructor)StructBuilder_dealloc,
+    .tp_traverse = (traverseproc)StructBuilder_traverse,
+    .tp_clear = (inquiry)StructBuilder_clear,
+};
+
+static void
+struct_builder_consume_values(PyObject **values, Py_ssize_t nslots)
+{
+    if (values == NULL || nslots <= 0) return;
+    for (Py_ssize_t i = 0; i < nslots; i++) {
+        Py_XDECREF(values[i]);
+        values[i] = NULL;
+    }
+}
+
+static int
+struct_builder_prepare(PyObject *cls_obj, PyObject **builder_out)
+{
+    if (builder_out == NULL) {
+        PyErr_SetString(PyExc_SystemError, "builder_out must not be NULL");
+        return MSGSPEC_CAPI_ERROR;
+    }
+    *builder_out = NULL;
+
+#ifdef Py_GIL_DISABLED
+    /* V1 deliberately makes no free-threaded safety claim. */
+    return MSGSPEC_CAPI_UNSUPPORTED;
+#else
+    /* msgspec is currently a legacy single-phase extension. V1 refuses
+     * subinterpreters rather than sharing an interpreter-affine token. */
+    if (PyInterpreterState_Get() != PyInterpreterState_Main()) {
+        return MSGSPEC_CAPI_UNSUPPORTED;
+    }
+
+    /* Custom StructMeta subclasses retain the public-constructor fallback. */
+    if (!PyType_Check(cls_obj) || Py_TYPE(cls_obj) != &StructMetaType) {
+        return MSGSPEC_CAPI_UNSUPPORTED;
+    }
+
+    StructBuilderObject *builder = (StructBuilderObject *)StructBuilder_Type.tp_alloc(
+        &StructBuilder_Type, 0
+    );
+    if (builder == NULL) return MSGSPEC_CAPI_ERROR;
+
+    builder->cls = (PyTypeObject *)Py_NewRef(cls_obj);
+    builder->st_type = (StructMetaObject *)cls_obj;
+    builder->nfields = PyTuple_GET_SIZE(builder->st_type->struct_fields);
+    *builder_out = (PyObject *)builder;
+    return MSGSPEC_CAPI_OK;
+#endif
+}
+
+static PyObject *
+struct_builder_build_owned(
+    PyObject *builder_obj,
+    PyObject **values,
+    Py_ssize_t nslots
+)
+{
+    if (MS_UNLIKELY(nslots < 0 || (nslots != 0 && values == NULL))) {
+        PyErr_SetString(PyExc_SystemError, "invalid declared-order value array");
+        return NULL;
+    }
+    if (MS_UNLIKELY(!Py_IS_TYPE(builder_obj, &StructBuilder_Type))) {
+        struct_builder_consume_values(values, nslots);
+        PyErr_SetString(PyExc_TypeError, "invalid msgspec Struct builder");
+        return NULL;
+    }
+
+    StructBuilderObject *builder = (StructBuilderObject *)builder_obj;
+    StructMetaObject *st_type = builder->st_type;
+    Py_ssize_t nfields = builder->nfields;
+
+    /* __abstractmethods__ is mutable after prepare. Match Struct_vectorcall. */
+    if (MS_UNLIKELY(builder->cls->tp_flags & Py_TPFLAGS_IS_ABSTRACT)) {
+        struct_builder_consume_values(values, nslots);
+        Struct_build_abstract_error(builder->cls);
+        return NULL;
+    }
+
+    if (MS_UNLIKELY(nslots != nfields)) {
+        struct_builder_consume_values(values, nslots);
+        PyErr_Format(
+            PyExc_TypeError,
+            "expected %zd declared-order fields, got %zd",
+            nfields,
+            nslots
+        );
+        return NULL;
+    }
+
+    Py_ssize_t ndefaults = PyTuple_GET_SIZE(st_type->struct_defaults);
+    Py_ssize_t npos = nfields - ndefaults;
+    bool is_gc = MS_TYPE_IS_GC(builder->cls);
+    bool should_untrack = is_gc;
+
+    PyObject *out = Struct_alloc(builder->cls);
+    if (out == NULL) {
+        struct_builder_consume_values(values, nslots);
+        return NULL;
+    }
+
+    for (Py_ssize_t i = 0; i < nfields; i++) {
+        PyObject *val = values[i];
+        values[i] = NULL;
+
+        if (val == NULL) {
+            if (MS_UNLIKELY(i < npos)) {
+                PyErr_Format(
+                    PyExc_TypeError,
+                    "Missing required argument '%U'",
+                    PyTuple_GET_ITEM(st_type->struct_fields, i)
+                );
+                goto error;
+            }
+            PyObject *def = PyTuple_GET_ITEM(st_type->struct_defaults, i - npos);
+            if (MS_UNLIKELY(def == NODEFAULT)) {
+                PyErr_Format(
+                    PyExc_TypeError,
+                    "Missing required argument '%U'",
+                    PyTuple_GET_ITEM(st_type->struct_fields, i)
+                );
+                goto error;
+            }
+            val = get_default(def);
+            if (MS_UNLIKELY(val == NULL)) goto error;
+        }
+
+        char *addr = (char *)out + st_type->struct_offsets[i];
+        *(PyObject **)addr = val;
+        if (should_untrack) should_untrack = !MS_MAYBE_TRACKED(val);
+    }
+
+    if (is_gc && should_untrack && MS_IS_TRACKED(out)) {
+        PyObject_GC_UnTrack(out);
+    }
+    if (Struct_post_init(st_type, out) < 0) goto error;
+    return out;
+
+error:
+    struct_builder_consume_values(values, nslots);
+    Py_DECREF(out);
+    return NULL;
+}
+
+static const Msgspec_CAPI_v1 msgspec_capi_v1 = {
+    .abi_version = MSGSPEC_CAPI_ABI_VERSION,
+    .struct_size = sizeof(Msgspec_CAPI_v1),
+#ifndef Py_GIL_DISABLED
+    .capabilities = MSGSPEC_CAPI_CAP_STRUCT_BUILD_OWNED_V1,
+#else
+    .capabilities = 0,
+#endif
+    .struct_builder_prepare = struct_builder_prepare,
+    .struct_builder_build_owned = struct_builder_build_owned,
+};
 
 static PyTypeObject StructMetaType = {
     PyVarObject_HEAD_INIT(NULL, 0)
@@ -22836,6 +23045,8 @@ PyInit__core(void)
         return NULL;
     if (PyType_Ready(&StructMetaType) < 0)
         return NULL;
+    if (PyType_Ready(&StructBuilder_Type) < 0)
+        return NULL;
     if (PyType_Ready(&StructMixinType) < 0)
         return NULL;
     if (PyType_Ready(&StructConfig_Type) < 0)
@@ -23099,6 +23310,17 @@ PyInit__core(void)
         "__module__", "msgspec", "__doc__", Struct__doc__
     );
     if (PyModule_AddObjectRef(m, "Struct", st->StructType) < 0) return NULL;
+    PyObject *capi = PyCapsule_New(
+        (void *)&msgspec_capi_v1,
+        MSGSPEC_CAPI_CAPSULE_NAME,
+        NULL
+    );
+    if (capi == NULL) return NULL;
+    if (PyModule_AddObjectRef(m, "_C_API_v1", capi) < 0) {
+        Py_DECREF(capi);
+        return NULL;
+    }
+    Py_DECREF(capi);
 #ifdef Py_GIL_DISABLED
     PyUnstable_Module_SetGIL(m, Py_MOD_GIL_NOT_USED);
 #endif

--- a/src/msgspec/_testcapi.c
+++ b/src/msgspec/_testcapi.c
@@ -1,0 +1,81 @@
+#define PY_SSIZE_T_CLEAN
+#include <Python.h>
+#include "msgspec.h"
+
+static const Msgspec_CAPI_v1 *capi = NULL;
+static PyObject *absent = NULL;
+
+static PyObject *
+testcapi_capabilities(PyObject *Py_UNUSED(self), PyObject *Py_UNUSED(args))
+{
+    return PyLong_FromUnsignedLongLong(capi->capabilities);
+}
+
+static PyObject *
+testcapi_prepare(PyObject *Py_UNUSED(self), PyObject *cls)
+{
+    PyObject *builder = NULL;
+    int status = capi->struct_builder_prepare(cls, &builder);
+    if (status == MSGSPEC_CAPI_OK) return builder;
+    if (status == MSGSPEC_CAPI_UNSUPPORTED) Py_RETURN_NONE;
+    return NULL;
+}
+
+static PyObject *
+testcapi_build(PyObject *Py_UNUSED(self), PyObject *args)
+{
+    PyObject *builder;
+    PyObject *items;
+    if (!PyArg_ParseTuple(args, "OO!:build", &builder, &PyTuple_Type, &items)) {
+        return NULL;
+    }
+
+    Py_ssize_t nslots = PyTuple_GET_SIZE(items);
+    PyObject **values = PyMem_Calloc((size_t)nslots, sizeof(PyObject *));
+    if (values == NULL && nslots != 0) return PyErr_NoMemory();
+
+    for (Py_ssize_t i = 0; i < nslots; i++) {
+        PyObject *item = PyTuple_GET_ITEM(items, i);
+        if (item != absent) values[i] = Py_NewRef(item);
+    }
+
+    PyObject *out = capi->struct_builder_build_owned(builder, values, nslots);
+    PyMem_Free(values);
+    return out;
+}
+
+static PyMethodDef methods[] = {
+    {"capabilities", testcapi_capabilities, METH_NOARGS, NULL},
+    {"prepare", testcapi_prepare, METH_O, NULL},
+    {"build", testcapi_build, METH_VARARGS, NULL},
+    {NULL, NULL, 0, NULL},
+};
+
+static struct PyModuleDef module = {
+    PyModuleDef_HEAD_INIT,
+    .m_name = "msgspec._testcapi",
+    .m_size = -1,
+    .m_methods = methods,
+};
+
+PyMODINIT_FUNC
+PyInit__testcapi(void)
+{
+    capi = Msgspec_ImportCAPI_v1();
+    if (capi == NULL) return NULL;
+
+    PyObject *mod = PyModule_Create(&module);
+    if (mod == NULL) return NULL;
+
+    absent = PyCapsule_New((void *)&absent, "msgspec._testcapi.ABSENT", NULL);
+    if (absent == NULL) {
+        Py_DECREF(mod);
+        return NULL;
+    }
+    if (PyModule_AddObjectRef(mod, "ABSENT", absent) < 0) {
+        Py_CLEAR(absent);
+        Py_DECREF(mod);
+        return NULL;
+    }
+    return mod;
+}

--- a/src/msgspec/msgspec.h
+++ b/src/msgspec/msgspec.h
@@ -1,0 +1,83 @@
+#ifndef MSGSPEC_CAPI_H
+#define MSGSPEC_CAPI_H
+
+#include <Python.h>
+#include <stddef.h>
+#include <stdint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/*
+ * msgspec native C API, ABI major 1.
+ *
+ * This header exposes no msgspec object layouts. The capsule table is an
+ * opaque, versioned capability boundary implemented by msgspec.
+ */
+#define MSGSPEC_CAPI_CAPSULE_NAME "msgspec._core._C_API_v1"
+
+#define MSGSPEC_CAPI_ABI_MAKE(major, minor) \
+    ((((uint32_t)(major)) << 16) | ((uint32_t)(minor) & 0xffffu))
+#define MSGSPEC_CAPI_ABI_VERSION MSGSPEC_CAPI_ABI_MAKE(1, 0)
+#define MSGSPEC_CAPI_ABI_MAJOR(v) ((uint32_t)(v) >> 16)
+#define MSGSPEC_CAPI_ABI_MINOR(v) ((uint32_t)(v) & 0xffffu)
+
+#define MSGSPEC_CAPI_OK          0
+#define MSGSPEC_CAPI_UNSUPPORTED 1
+#define MSGSPEC_CAPI_ERROR      -1
+
+#define MSGSPEC_CAPI_CAP_STRUCT_BUILD_OWNED_V1 (1ull << 0)
+
+/*
+ * struct_builder_prepare:
+ * - OK returns a new opaque Python token in builder_out.
+ * - UNSUPPORTED is a normal fallback signal and sets no exception.
+ * - ERROR sets an exception.
+ *
+ * struct_builder_build_owned:
+ * - values contains exactly nslots declared-field positions.
+ * - each non-NULL entry is one owned reference transferred by the call.
+ * - NULL means absent and carries no ownership.
+ * - for a valid builder, all non-NULL entries are consumed on success or
+ *   failure. The caller must treat every entry as moved after the call.
+ * - success returns a new reference; failure returns NULL with an exception.
+ */
+typedef struct Msgspec_CAPI_v1 {
+    uint32_t abi_version;
+    uint32_t struct_size;
+    uint64_t capabilities;
+
+    int (*struct_builder_prepare)(PyObject *cls, PyObject **builder_out);
+    PyObject *(*struct_builder_build_owned)(
+        PyObject *builder,
+        PyObject **values,
+        Py_ssize_t nslots
+    );
+} Msgspec_CAPI_v1;
+
+#define MSGSPEC_CAPI_V1_STRUCT_BUILD_OWNED_MIN_SIZE \
+    (offsetof(Msgspec_CAPI_v1, struct_builder_build_owned) + \
+     sizeof(((Msgspec_CAPI_v1 *)0)->struct_builder_build_owned))
+
+static inline const Msgspec_CAPI_v1 *
+Msgspec_ImportCAPI_v1(void)
+{
+    const Msgspec_CAPI_v1 *api = (const Msgspec_CAPI_v1 *)PyCapsule_Import(
+        MSGSPEC_CAPI_CAPSULE_NAME, 0
+    );
+    if (api == NULL) return NULL;
+    if (MSGSPEC_CAPI_ABI_MAJOR(api->abi_version) != 1 ||
+        api->struct_size < MSGSPEC_CAPI_V1_STRUCT_BUILD_OWNED_MIN_SIZE ||
+        !(api->capabilities & MSGSPEC_CAPI_CAP_STRUCT_BUILD_OWNED_V1)) {
+        PyErr_SetString(PyExc_ImportError, "incompatible msgspec C API v1");
+        return NULL;
+    }
+    return api;
+}
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* MSGSPEC_CAPI_H */

--- a/tests/unit/test_capi.py
+++ b/tests/unit/test_capi.py
@@ -1,0 +1,92 @@
+import gc
+import weakref
+
+import pytest
+
+import msgspec
+
+testcapi = pytest.importorskip(
+    "msgspec._testcapi",
+    reason="build with MSGSPEC_COMPILE_TEST_CAPI=1 to test the native C API",
+)
+
+
+def test_capability_is_advertised():
+    assert testcapi.capabilities() & 1
+
+
+def test_declared_order_and_none_value():
+    class Example(msgspec.Struct, kw_only=True, rename="camel"):
+        first_name: str
+        value: object
+
+    builder = testcapi.prepare(Example)
+    out = testcapi.build(builder, ("a", None))
+    assert out == Example(first_name="a", value=None)
+
+
+def test_defaults_factories_and_post_init():
+    seen = []
+
+    class Example(msgspec.Struct):
+        required: int
+        defaulted: int = 2
+        generated: list = msgspec.field(default_factory=list)
+
+        def __post_init__(self):
+            seen.append(self)
+
+    builder = testcapi.prepare(Example)
+    out = testcapi.build(
+        builder,
+        (1, testcapi.ABSENT, testcapi.ABSENT),
+    )
+    assert (out.required, out.defaulted, out.generated) == (1, 2, [])
+    assert out.generated == []
+    assert seen == [out]
+
+
+def test_required_and_slot_count_errors():
+    class Example(msgspec.Struct):
+        value: int
+
+    builder = testcapi.prepare(Example)
+    with pytest.raises(TypeError, match="Missing required argument 'value'"):
+        testcapi.build(builder, (testcapi.ABSENT,))
+    with pytest.raises(TypeError, match="expected 1 declared-order fields, got 0"):
+        testcapi.build(builder, ())
+
+
+def test_abstractness_is_checked_at_build_time():
+    class Example(msgspec.Struct):
+        value: int
+
+    builder = testcapi.prepare(Example)
+    Example.__abstractmethods__ = frozenset({"value"})
+    with pytest.raises(TypeError, match="abstract"):
+        testcapi.build(builder, (1,))
+
+
+def test_custom_struct_meta_uses_fallback():
+    class Meta(msgspec.StructMeta):
+        pass
+
+    class Example(msgspec.Struct, metaclass=Meta):
+        value: int
+
+    assert testcapi.prepare(Example) is None
+
+
+def test_builder_cycle_is_collectable():
+    def make_cycle():
+        class Example(msgspec.Struct):
+            value: int
+
+        ref = weakref.ref(Example)
+        Example._builder_cycle = testcapi.prepare(Example)
+        return ref
+
+    ref = make_cycle()
+    assert ref() is not None
+    gc.collect()
+    assert ref() is None


### PR DESCRIPTION
## What this draft tests

This is a deliberately narrow alternative/complement to #961: one opaque,
versioned C-API capability for constructing an already-validated `msgspec.Struct`
from declared-order owned references. It does not expose msgspec's private
layouts, offsets, metaclass construction, encoders, or decoders.

The concrete consumer is a native TOON decoder. Its parser already knows the
target schema and has final Python field values, but today it must call the
public Struct constructor, which repeats argument binding. The proposed call
lets msgspec retain ownership of allocation, defaults/factories, GC decisions,
abstract checks, and `__post_init__` while removing that duplicate binding work.

## Safety and fallback

- The returned builder is an opaque Python object, not a raw private-layout
  handle.
- It participates in cyclic GC. The test suite covers the class -> token ->
  class cycle found during external review.
- The build call has an explicit consume-on-success-and-failure ownership
  contract.
- Unsupported class/metaclass/interpreter configurations return a normal
  fallback status without an exception.
- V1 advertises no capability on free-threaded builds.
- The public header and table are size/capability/version checked.

## Evidence

- CPython 3.13 upstream unit suite: 6,387 passed, 143 skipped.
- CPython 3.14 free-threaded upstream unit suite: 6,369 passed, 155 skipped.
- Focused API/lifecycle tests: 7 passed.
- TOON 4.1.1 corpus through the consumer: 538/538; strict errors 84/84.
- Matched current-main A/B, same codec wheel and same msgspec base commit:
  S1 about 3% faster (resolved only after doubled sampling), S6 about 3% faster
  but unresolved on confirmation, and S12 about 5% faster and resolved.

This is a draft to discuss whether this small producer-owned capability is a
maintainable first C-API boundary. Production `msgspec-toon` remains pinned to
stock `msgspec==0.21.1`; no patched dependency is shipped.

Thank you to @Vizonex and the participants in #958/#961 for establishing the
capsule/test-module prior art and surfacing the broader extension use cases.
