### PR TITLE
Support Optional[Raw] when decoding JSON and MessagePack

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+- Support `Optional[msgspec.Raw]` / `Raw | None` when decoding JSON and MessagePack ({issue}`659`).
+
 ## Version 0.22.0 (2026-08-11)
 
 - Add `frozendict` support on Python 3.15+ ({pr}`1052`, {pr}`1105`).

--- a/src/msgspec/_core.c
+++ b/src/msgspec/_core.c
@@ -2852,6 +2852,7 @@ AssocList_Sort(AssocList* list) {
 // Despite the fact that `frozendict` was added in 3.15,
 // this type is always defined for order consistency:
 #define MS_TYPE_FROZENDICT          ((1ull << 38) | (1ull << 39))
+#define MS_TYPE_RAW                 (1ull << 40)
 
 /* Aliases for commonly used types */
 #if PY315_PLUS
@@ -3489,7 +3490,7 @@ static PyObject *
 typenode_simple_repr(TypeNode *self) {
     strbuilder builder = {" | ", 3};
 
-    if (self->types & (MS_TYPE_ANY | MS_TYPE_CUSTOM | MS_TYPE_CUSTOM_GENERIC) || self->types == 0) {
+    if (self->types & (MS_TYPE_ANY | MS_TYPE_CUSTOM | MS_TYPE_CUSTOM_GENERIC | MS_TYPE_RAW) || self->types == 0) {
         return PyUnicode_FromString("any");
     }
     if (self->types & (MS_TYPE_BOOL | MS_TYPE_BOOLLITERAL_TRUE | MS_TYPE_BOOLLITERAL_FALSE)) {
@@ -4168,6 +4169,20 @@ typenode_collect_check_invariants(TypeNodeCollectState *state) {
             PyExc_TypeError,
             "Type unions containing a custom type may not contain any "
             "additional types other than `None` - type `%R` is not supported",
+            state->context
+        );
+        return -1;
+    }
+
+    /* Raw may only share a union with `None` (Optional[Raw] / Raw | None) */
+    if (
+        (state->types & MS_TYPE_RAW) &&
+        (state->types & ~(MS_TYPE_RAW | MS_TYPE_NONE))
+    ) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "Type unions containing `Raw` may not contain any additional "
+            "types other than `None` - type `%R` is not supported",
             state->context
         );
         return -1;
@@ -5117,7 +5132,7 @@ typenode_collect_type(TypeNodeCollectState *state, PyObject *obj) {
         state->types |= MS_TYPE_EXT;
     }
     else if (t == (PyObject *)(&Raw_Type)) {
-        /* Raw is marked with a typecode of 0, nothing to do */
+        state->types |= MS_TYPE_RAW;
     }
     else if (Py_TYPE(t) == (PyTypeObject *)(state->mod->typing_typevar)) {
         out = typenode_collect_typevar(state, t);
@@ -16751,7 +16766,17 @@ static PyObject *
 mpack_decode(
     DecoderState *self, TypeNode *type, PathNode *path, bool is_key
 ) {
-    if (MS_UNLIKELY(type->types == 0)) {
+    if (MS_UNLIKELY(type->types == 0 || (type->types & MS_TYPE_RAW))) {
+        if (type->types & MS_TYPE_NONE) {
+            if (MS_UNLIKELY(self->input_pos == self->input_end)) {
+                ms_err_truncated();
+                return NULL;
+            }
+            if (*self->input_pos == MP_NIL) {
+                self->input_pos++;
+                return mpack_decode_none(self, type, path);
+            }
+        }
         return mpack_decode_raw(self);
     }
     PyObject *obj = mpack_decode_nocustom(self, type, path, is_key);
@@ -19260,7 +19285,14 @@ static PyObject *
 json_decode(
     JSONDecoderState *self, TypeNode *type, PathNode *path
 ) {
-    if (MS_UNLIKELY(type->types == 0)) {
+    if (MS_UNLIKELY(type->types == 0 || (type->types & MS_TYPE_RAW))) {
+        if (type->types & MS_TYPE_NONE) {
+            unsigned char c;
+            if (MS_UNLIKELY(!json_peek_skip_ws(self, &c))) return NULL;
+            if (c == 'n') {
+                return json_decode_none(self, type, path);
+            }
+        }
         return json_decode_raw(self);
     }
     PyObject *obj = json_decode_nocustom(self, type, path);
@@ -21289,7 +21321,7 @@ static PyObject *
 convert_raw(
     ConvertState *self, PyObject *obj, TypeNode *type, PathNode *path
 ) {
-    if (type->types == 0) {
+    if (type->types == 0 || (type->types & MS_TYPE_RAW)) {
         Py_INCREF(obj);
         return obj;
     }

--- a/tests/unit/test_convert.py
+++ b/tests/unit/test_convert.py
@@ -2769,3 +2769,12 @@ class TestRaw:
 
         sol = Ex(x=raw)
         assert convert({"x": raw}, type=Ex) == sol
+
+    def test_optional_raw(self):
+        raw = msgspec.Raw(b"123")
+
+        class Ex(Struct):
+            x: msgspec.Raw | None
+
+        assert convert({"x": raw}, type=Ex) == Ex(x=raw)
+        assert convert({"x": None}, type=Ex) == Ex(x=None)

--- a/tests/unit/test_json.py
+++ b/tests/unit/test_json.py
@@ -3103,23 +3103,48 @@ class TestRaw:
         del r
         assert sys.getrefcount(msg) == c
 
-    def test_raw_in_union_works_but_doesnt_change_anything(self):
+    def test_raw_in_union_only_allows_none(self):
         class Test(msgspec.Struct):
             x: int | str | msgspec.Raw
 
-        r = msgspec.json.decode(b'{"x": 1}', type=Test)
-        assert r == Test(1)
+        with pytest.raises(TypeError, match="Type unions containing"):
+            msgspec.json.decode(b'{"x": 1}', type=Test)
 
-    def test_raw_can_be_mixed_with_custom_type(self):
+    def test_raw_cannot_be_mixed_with_custom_type(self):
         class Test(msgspec.Struct):
             x: Custom | msgspec.Raw
 
-        def dec_hook(typ, obj):
-            assert typ is Custom
-            return typ(*obj)
+        with pytest.raises(TypeError, match="Type unions containing"):
+            msgspec.json.decode(b'{"x": [1, 2]}', type=Test)
 
-        res = msgspec.json.decode(b'{"x": [1, 2]}', type=Test, dec_hook=dec_hook)
-        assert res == Test(Custom(1, 2))
+    def test_decode_optional_raw_object(self):
+        class Test(msgspec.Struct):
+            result: msgspec.Raw | None
+
+        res = msgspec.json.decode(b'{"result": {"foo": "bar"}}', type=Test)
+        assert res.result is not None
+        assert bytes(res.result) == b'{"foo": "bar"}'
+
+    def test_decode_optional_raw_null(self):
+        class Test(msgspec.Struct):
+            result: msgspec.Raw | None
+
+        res = msgspec.json.decode(b'{"result": null}', type=Test)
+        assert res.result is None
+
+    def test_decode_optional_raw_scalar(self):
+        class Test(msgspec.Struct):
+            result: msgspec.Raw | None
+
+        res = msgspec.json.decode(b'{"result": 1}', type=Test)
+        assert bytes(res.result) == b"1"
+
+    def test_decode_optional_raw_missing_uses_default(self):
+        class Test(msgspec.Struct):
+            result: msgspec.Raw | None = None
+
+        res = msgspec.json.decode(b"{}", type=Test)
+        assert res.result is None
 
 
 class TestFormat:

--- a/tests/unit/test_msgpack.py
+++ b/tests/unit/test_msgpack.py
@@ -2033,22 +2033,43 @@ class TestRaw:
         assert bytes(r) == s
         assert r.copy() is not r  # actual copy indicates a view
 
-    def test_raw_in_union_works_but_doesnt_change_anything(self):
+    def test_raw_in_union_only_allows_none(self):
         class Test(msgspec.Struct):
             x: int | str | msgspec.Raw
 
         s = msgspec.msgpack.encode({"x": 1})
-        r = msgspec.msgpack.decode(s, type=Test)
-        assert r == Test(1)
+        with pytest.raises(TypeError, match="Type unions containing"):
+            msgspec.msgpack.decode(s, type=Test)
 
-    def test_raw_can_be_mixed_with_custom_type(self):
+    def test_raw_cannot_be_mixed_with_custom_type(self):
         class Test(msgspec.Struct):
             x: Custom | msgspec.Raw
 
-        def dec_hook(typ, obj):
-            assert typ is Custom
-            return typ(*obj)
-
         s = msgspec.msgpack.encode({"x": [1, 2]})
-        res = msgspec.msgpack.decode(s, type=Test, dec_hook=dec_hook)
-        assert res == Test(Custom(1, 2))
+        with pytest.raises(TypeError, match="Type unions containing"):
+            msgspec.msgpack.decode(s, type=Test)
+
+    def test_decode_optional_raw_object(self):
+        class Test(msgspec.Struct):
+            result: msgspec.Raw | None
+
+        s = msgspec.msgpack.encode({"result": {"foo": "bar"}})
+        res = msgspec.msgpack.decode(s, type=Test)
+        assert res.result is not None
+        assert bytes(res.result) == msgspec.msgpack.encode({"foo": "bar"})
+
+    def test_decode_optional_raw_null(self):
+        class Test(msgspec.Struct):
+            result: msgspec.Raw | None
+
+        s = msgspec.msgpack.encode({"result": None})
+        res = msgspec.msgpack.decode(s, type=Test)
+        assert res.result is None
+
+    def test_decode_optional_raw_scalar(self):
+        class Test(msgspec.Struct):
+            result: msgspec.Raw | None
+
+        s = msgspec.msgpack.encode({"result": 1})
+        res = msgspec.msgpack.decode(s, type=Test)
+        assert bytes(res.result) == msgspec.msgpack.encode(1)


### PR DESCRIPTION
Fixes #659.

`msgspec.Raw` was collected with a type mask of 0, so `Optional[Raw]` / `Raw | None` never recorded `MS_TYPE_NONE`. JSON and MessagePack then treated `null` as a `Raw` payload (`b"null"`) instead of `None`, which is the reproduction in #659.

This follows the design from the issue: `Raw` is allowed in a union only with `None`. `null` decodes as `None`; any other value decodes as `Raw`. Unions such as `Raw | int` now raise `TypeError`, matching the existing custom-type restriction.

Changes:
- Give `Raw` its own `MS_TYPE_RAW` flag and reject unsupported `Raw` unions at type-collection time.
- Peek for JSON `null` / MessagePack nil when decoding `Raw | None`.
- Accept `Raw | None` in `convert`.
- Add JSON, MessagePack, and `convert` tests for the `null` and non-null cases.