### PR TITLE
Fix serializing `list` subclasses with external storage

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## Unreleased
+
+- Fix `list` subclasses that store their items outside of the internal list
+  storage (such as classes inheriting from both `list` and
+  `collections.UserList`) silently encoding as an empty array. They are now
+  encoded via the sequence protocol ({issue}`1156`).
+
 ## Version 0.22.0 (2026-08-11)
 
 - Add `frozendict` support on Python 3.15+ ({pr}`1052`, {pr}`1105`).

--- a/src/msgspec/_core.c
+++ b/src/msgspec/_core.c
@@ -3137,6 +3137,21 @@ ms_is_struct_inst(PyObject *o) {
     return ms_is_struct_meta(Py_TYPE((PyObject *)Py_TYPE(o)));
 }
 
+static MS_INLINE bool
+ms_list_is_plain(PyObject *obj) {
+    /* Checks whether a `list` instance stores its items in the internal list
+     * storage. Some subclasses of `list`, such as those combining it with
+     * `collections.UserList`, may store items elsewhere, only reachable
+     * through the sequence protocol. */
+    PyTypeObject *type = Py_TYPE(obj);
+    if (MS_LIKELY(type == &PyList_Type)) return true;
+    return (
+        type->tp_iter == PyList_Type.tp_iter
+        && type->tp_as_sequence->sq_length == PyList_Type.tp_as_sequence->sq_length
+        && type->tp_as_sequence->sq_item == PyList_Type.tp_as_sequence->sq_item
+    );
+}
+
 static MS_INLINE StructInfo *
 TypeNode_get_struct_info(TypeNode *type) {
     /* Struct types are always first */
@@ -12953,6 +12968,22 @@ mpack_encode_list(EncoderState *self, PyObject *obj)
     Py_ssize_t i, len;
     int status = 0;
 
+    if (MS_UNLIKELY(!ms_list_is_plain(obj))) {
+        /* Items are stored outside of the internal list storage, copy them out
+         * through the sequence protocol first */
+        if (Py_EnterRecursiveCall(" while serializing an object")) return -1;
+        PyObject *temp = PySequence_List(obj);
+        if (temp != NULL) {
+            status = mpack_encode_list(self, temp);
+            Py_DECREF(temp);
+        }
+        else {
+            status = -1;
+        }
+        Py_LeaveRecursiveCall();
+        return status;
+    }
+
     len = PyList_GET_SIZE(obj);
     if (len == 0) return mpack_encode_empty_array(self);
 
@@ -14298,6 +14329,23 @@ static MS_NOINLINE int
 json_encode_list(EncoderState *self, PyObject *obj)
 {
     int ret;
+
+    if (MS_UNLIKELY(!ms_list_is_plain(obj))) {
+        /* Items are stored outside of the internal list storage, copy them out
+         * through the sequence protocol first */
+        if (Py_EnterRecursiveCall(" while serializing an object")) return -1;
+        PyObject *temp = PySequence_List(obj);
+        if (temp != NULL) {
+            ret = json_encode_list(self, temp);
+            Py_DECREF(temp);
+        }
+        else {
+            ret = -1;
+        }
+        Py_LeaveRecursiveCall();
+        return ret;
+    }
+
     Py_BEGIN_CRITICAL_SECTION(obj);
     ret = json_encode_sequence(
         self, PyList_GET_SIZE(obj), ((PyListObject *)obj)->ob_item
@@ -14936,7 +14984,7 @@ JSONEncoder_encode_lines(Encoder *self, PyObject *const *args, Py_ssize_t nargs)
     state.output_buffer_raw = PyBytes_AS_STRING(state.output_buffer);
 
     PyObject *input = args[0];
-    if (MS_LIKELY(PyList_Check(input))) {
+    if (MS_LIKELY(PyList_Check(input) && ms_list_is_plain(input))) {
         for (Py_ssize_t i = 0; i < PyList_GET_SIZE(input); i++) {
             if (json_encode(&state, PyList_GET_ITEM(input, i)) < 0) goto error;
             if (ms_write(&state, "\n", 1) < 0) goto error;
@@ -20153,6 +20201,19 @@ static PyObject *
 to_builtins_list(ToBuiltinsState *self, PyObject *obj) {
     if (Py_EnterRecursiveCall(" while serializing an object")) return NULL;
 
+    if (MS_UNLIKELY(!ms_list_is_plain(obj))) {
+        /* Items are stored outside of the internal list storage, copy them out
+         * through the sequence protocol first */
+        PyObject *out = NULL;
+        PyObject *temp = PySequence_List(obj);
+        if (temp != NULL) {
+            out = to_builtins_list(self, temp);
+            Py_DECREF(temp);
+        }
+        Py_LeaveRecursiveCall();
+        return out;
+    }
+
     Py_ssize_t size = PyList_GET_SIZE(obj);
     PyObject *out = PyList_New(size);
     if (out == NULL) goto cleanup;
@@ -22390,6 +22451,19 @@ convert(
         return convert_float(self, obj, type, path);
     }
     else if (PyList_Check(obj)) {
+        if (MS_UNLIKELY(!ms_list_is_plain(obj))) {
+            /* Items are stored outside of the internal list storage, copy them
+             * out through the sequence protocol first */
+            PyObject *out = NULL;
+            PyObject *temp = PySequence_List(obj);
+            if (temp != NULL) {
+                out = convert_seq(
+                    self, LIST_ITEMS(temp), PyList_GET_SIZE(temp), type, path
+                );
+                Py_DECREF(temp);
+            }
+            return out;
+        }
         return convert_seq(self, LIST_ITEMS(obj), PyList_GET_SIZE(obj), type, path);
     }
     else if (pytype == &PyTuple_Type) {

--- a/tests/unit/test_common.py
+++ b/tests/unit/test_common.py
@@ -168,6 +168,43 @@ class TestEncodeSubclasses:
         for msg in [[], [1, 2]]:
             assert proto.encode(subclass(msg)) == proto.encode(cls(msg))
 
+    def test_encode_list_subclass_with_external_storage(self, proto):
+        """Types like `collections.UserList` store their items outside of the
+        internal list storage, and are only reachable through the sequence
+        protocol."""
+
+        class subclass(collections.UserList, list):
+            pass
+
+        for msg in [[], [1, 2]]:
+            assert proto.encode(subclass(msg)) == proto.encode(msg)
+
+    def test_encode_list_subclass_custom_iter(self, proto):
+        class subclass(list):
+            def __iter__(self):
+                return iter(["a", "b"])
+
+        assert proto.encode(subclass()) == proto.encode(["a", "b"])
+
+    def test_encode_list_subclass_getitem_errors(self, proto):
+        class subclass(collections.UserList, list):
+            def __getitem__(self, i):
+                raise ValueError("oh no")
+
+        with pytest.raises(ValueError, match="oh no"):
+            proto.encode(subclass([1, 2]))
+
+    @emscripten_stack_limited
+    def test_encode_list_subclass_recursive(self, proto):
+        class subclass(collections.UserList, list):
+            pass
+
+        o = subclass()
+        o.append(o)
+
+        with pytest.raises(RecursionError):
+            proto.encode(o)
+
 
 class TestDecoder:
     def test_decoder_runtime_type_parameters(self, proto):

--- a/tests/unit/test_convert.py
+++ b/tests/unit/test_convert.py
@@ -1,3 +1,4 @@
+import collections
 import datetime
 import decimal
 import enum
@@ -989,6 +990,17 @@ class TestSequences:
             ValidationError, match=r"Expected `int`, got `str` - at `\$\[0\]`"
         ):
             assert convert(in_type(["bad"]), out_annot)
+
+    @pytest.mark.parametrize("out_type", [list, tuple, set, frozenset])
+    def test_list_subclass_with_external_storage(self, out_type):
+        class in_type(collections.UserList, list):
+            pass
+
+        res = convert(in_type([1, 2]), out_type)
+        assert res == out_type([1, 2])
+        assert type(res) is out_type
+
+        assert convert(in_type(), out_type) == out_type()
 
     @pytest.mark.parametrize("out_type", [list, tuple, set, frozenset])
     def test_sequence_wrong_type(self, out_type):

--- a/tests/unit/test_json.py
+++ b/tests/unit/test_json.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import base64
+import collections
 import datetime
 import decimal
 import enum

--- a/tests/unit/test_to_builtins.py
+++ b/tests/unit/test_to_builtins.py
@@ -1,4 +1,5 @@
 import base64
+import collections
 import datetime
 import decimal
 import enum
@@ -247,6 +248,17 @@ class TestToBuiltins:
 
         res = to_builtins(in_type())
         assert res == out_type()
+
+    def test_list_subclass_with_external_storage(self):
+        class subclass(collections.UserList, list):
+            pass
+
+        msg = subclass([1, FruitInt.APPLE])
+        res = to_builtins(msg)
+        assert res == [1, -1]
+        assert type(res) is list
+
+        assert to_builtins(subclass()) == []
 
     @pytest.mark.parametrize("in_type", [list, tuple, set, frozenset])
     def test_sequence_unsupported_item(self, in_type):


### PR DESCRIPTION
Fixes #1156.

The new `ms_list_is_plain` function checks whether a `list` subclass stores its items in the internal list storage, and if not, copies the items out through the sequence protocol before serializing. This ensures that `list` subclasses are not serialized to an empty array.