### PR TITLE
Fix JSON schema metadata for dictionary keys

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## Unreleased
+
+- Preserve JSON Schema metadata and string constraints in `propertyNames` for
+  annotated dictionary key types ({issue}`866`).
+
 ## Version 0.22.0 (2026-08-11)
 
 - Add `frozendict` support on Python 3.15+ ({pr}`1052`, {pr}`1105`).

--- a/src/msgspec/_json_schema.py
+++ b/src/msgspec/_json_schema.py
@@ -310,15 +310,14 @@ class _SchemaGenerator:
                 schema["items"] = False
         elif isinstance(t, (mi.DictType, mi.FrozenDictType)):
             schema["type"] = "object"
-            # If there are restrictions on the keys, specify them as propertyNames
-            if isinstance(key_type := t.key_type, mi.StrType):
-                property_names: dict[str, Any] = {}
-                if key_type.min_length is not None:
-                    property_names["minLength"] = key_type.min_length
-                if key_type.max_length is not None:
-                    property_names["maxLength"] = key_type.max_length
-                if key_type.pattern is not None:
-                    property_names["pattern"] = key_type.pattern
+            # If keys have schema metadata or constraints, include them as propertyNames
+            key_type = t.key_type
+            while isinstance(key_type, mi.Metadata):
+                key_type = key_type.type
+            if isinstance(key_type, mi.StrType):
+                property_names = self.to_schema(t.key_type)
+                # Object property names are always strings, so omit the redundant type
+                property_names.pop("type", None)
                 if property_names:
                     schema["propertyNames"] = property_names
             if not isinstance(t.value_type, mi.AnyType):

--- a/tests/unit/test_schema.py
+++ b/tests/unit/test_schema.py
@@ -1208,6 +1208,25 @@ def test_dict_key_metadata(field, val, constraint):
     }
 
 
+@pytest.mark.parametrize(
+    "meta, property_names",
+    [
+        (Meta(title="key"), {"title": "key"}),
+        (
+            Meta(title="key", pattern="^A$"),
+            {"title": "key", "pattern": "^A$"},
+        ),
+    ],
+)
+def test_dict_key_metadata_with_schema_metadata(meta, property_names):
+    typ = Annotated[str, meta]
+    assert msgspec.json.schema(dict[typ, int]) == {
+        "type": "object",
+        "additionalProperties": {"type": "integer"},
+        "propertyNames": property_names,
+    }
+
+
 @pytest.mark.parametrize("typ", [bytes, bytearray, memoryview])
 @pytest.mark.parametrize(
     "field, n, constraint",


### PR DESCRIPTION
Fixes #866.

Dictionary key annotations with JSON Schema metadata are represented internally as Metadata wrappers. The dictionary schema branch only recognized a bare StrType, so adding metadata such as title caused both that metadata and string constraints to disappear from propertyNames.

This change verifies that the wrapped key is a string, generates propertyNames from the original annotated key schema, and removes the redundant string type. Existing behavior for plain and constraint-only string keys is preserved.

Validation:
- Full unit suite: 6412 passed, 113 skipped
- JSON Schema tests: 124 passed, 2 skipped
- Doctests: 7 passed
- Repository hooks: lint, format, and spelling passed

AI assistance disclosure: OpenAI Codex helped investigate, implement, and test this change. The account owner authorized publication; upstream workflows still require maintainer approval before they can run.