### PR TITLE
Fix SystemError when convert()'ing an out-of-range int to float

### DIFF
--- a/src/msgspec/_core.c
+++ b/src/msgspec/_core.c
@@ -20937,7 +20937,14 @@ convert_int(
         return ms_decode_int_enum_or_literal_pyint(obj, type, path);
     }
     else if (type->types & MS_TYPE_FLOAT) {
-        return ms_decode_float(PyLong_AsDouble(obj), type, path);
+        double val = PyLong_AsDouble(obj);
+        if (val == -1.0 && PyErr_Occurred()) {
+            /* `obj` is out of range for a C double (PyLong_AsDouble sets
+             * OverflowError but still returns -1.0); without this check
+             * that error leaks past this function as a SystemError. */
+            return ms_error_with_path("Number out of range%U", path);
+        }
+        return ms_decode_float(val, type, path);
     }
     else if (
         type->types & MS_TYPE_DECIMAL

--- a/tests/unit/test_convert.py
+++ b/tests/unit/test_convert.py
@@ -429,6 +429,17 @@ class TestFloat:
         with pytest.raises(ValidationError, match="Expected `float`, got `null`"):
             convert(None, float)
 
+    @pytest.mark.parametrize("strict", [True, False])
+    def test_float_from_int_out_of_range(self, strict):
+        # A python int too large to represent as a C double must raise a
+        # ValidationError, matching json.decode, rather than leaking the
+        # OverflowError PyLong_AsDouble sets as a SystemError.
+        big = 10**400
+        with pytest.raises(ValidationError, match="Number out of range"):
+            convert(big, float, strict=strict)
+        with pytest.raises(ValidationError, match="Number out of range"):
+            convert({"x": big}, dict[str, float], strict=strict)
+
     @pytest.mark.parametrize(
         "meta, good, bad",
         [


### PR DESCRIPTION
## Summary

`msgspec.convert(obj, float)` converts a Python `int` to a C `double` via `PyLong_AsDouble` without checking for overflow. For an `int` too large to represent as a finite `float` (e.g. `10**400`), `PyLong_AsDouble` sets `OverflowError` internally but still returns `-1.0`, and that value was passed straight through to `ms_decode_float` and returned to the interpreter with the exception still set — which surfaces as:

```
SystemError: <built-in function convert> returned a result with an exception set
```

This bypasses the documented `ValidationError` contract entirely, so a caller wrapping the call in `except msgspec.ValidationError` doesn't catch it.

`json.decode` already handles the equivalent case correctly, raising `ValidationError: Number out of range`. This PR applies the same "check `PyErr_Occurred()` after a lossy C conversion, then report via `ms_error_with_path`" pattern already used elsewhere in this file (e.g. `_constr_as_f64`), so `convert()` reports the overflow the same way — for both bare (`convert(big, float)`) and nested (`convert({"x": big}, dict[str, float])`) targets, under both `strict=True` and `strict=False`.

Fixes #1122.

## Testing

- Reverted the fix locally and reproduced the exact reported `SystemError` before reapplying it.
- Added `test_float_from_int_out_of_range` to `TestFloat` in `tests/unit/test_convert.py`, covering bare and nested targets under both strict modes.
- Ran the full `tests/unit/` suite: 6052 passed, 473 skipped, 0 failures.