### PR TITLE
Raise ValidationError instead of leaking SystemError on int->float overflow

### DIFF
--- a/src/msgspec/_core.c
+++ b/src/msgspec/_core.c
@@ -20937,7 +20937,17 @@ convert_int(
         return ms_decode_int_enum_or_literal_pyint(obj, type, path);
     }
     else if (type->types & MS_TYPE_FLOAT) {
-        return ms_decode_float(PyLong_AsDouble(obj), type, path);
+        double x = PyLong_AsDouble(obj);
+        if (MS_UNLIKELY(x == -1.0 && PyErr_Occurred())) {
+            /* obj is too large to fit in a C double. PyLong_AsDouble already
+             * set OverflowError; clear it and report the same "Number out of
+             * range" ValidationError json.decode already raises for the
+             * equivalent case, rather than letting the pending exception
+             * surface as a SystemError once this function returns. */
+            PyErr_Clear();
+            return ms_error_with_path("Number out of range%U", path);
+        }
+        return ms_decode_float(x, type, path);
     }
     else if (
         type->types & MS_TYPE_DECIMAL

--- a/tests/unit/test_convert.py
+++ b/tests/unit/test_convert.py
@@ -429,6 +429,25 @@ class TestFloat:
         with pytest.raises(ValidationError, match="Expected `float`, got `null`"):
             convert(None, float)
 
+    @pytest.mark.parametrize("strict", [True, False])
+    def test_float_from_int_out_of_range(self, strict):
+        """An int too large for a C double used to leak a SystemError
+        instead of the same "Number out of range" ValidationError
+        json.decode already raises for the equivalent case (msgspec#1122)."""
+        too_big = 10**400
+
+        with pytest.raises(ValidationError, match="Number out of range"):
+            convert(too_big, float, strict=strict)
+
+        # Also affects a nested target, not just a bare float
+        with pytest.raises(ValidationError, match="Number out of range"):
+            convert({"v": too_big}, dict[str, float], strict=strict)
+        with pytest.raises(ValidationError, match="Number out of range"):
+            convert([too_big], list[float], strict=strict)
+
+        # A normal in-range int is unaffected
+        assert convert(5, float, strict=strict) == 5.0
+
     @pytest.mark.parametrize(
         "meta, good, bad",
         [


### PR DESCRIPTION
Fixes #1122

`convert()`'s int-to-float branch passes `PyLong_AsDouble`'s result straight to `ms_decode_float` without checking whether that call actually succeeded. An int too large to fit in a C double makes `PyLong_AsDouble` raise `OverflowError` and return `-1.0`, and since nothing downstream noticed, the interpreter eventually caught a builtin function returning a result with a pending exception still set and raised its own generic `SystemError` instead of anything a caller could reasonably catch.

`json.decode` already handles the equivalent overflow correctly, reporting a plain `ValidationError: Number out of range`, so `convert()` now checks for the pending error right after the `PyLong_AsDouble` call and reports the same message rather than letting it leak through as a `SystemError`.

Added a test covering a bare `float` target as well as the same value nested in a `dict` and a `list`, for both `strict=True` and `strict=False`, since the original report notes this reaches any float-typed slot regardless of nesting, not just a top-level `convert(x, float)` call.

Ran the full test suite (`pytest tests/unit`, 6377 passed) plus `ruff check`/`ruff format --diff` and `codespell` on the changed files, all clean.
