### PR TITLE
Fix convert int→float overflow raising SystemError instead of ValidationError

### DIFF
--- a/src/msgspec/_core.c
+++ b/src/msgspec/_core.c
@@ -20937,7 +20937,12 @@ convert_int(
         return ms_decode_int_enum_or_literal_pyint(obj, type, path);
     }
     else if (type->types & MS_TYPE_FLOAT) {
-        return ms_decode_float(PyLong_AsDouble(obj), type, path);
+        double x = PyLong_AsDouble(obj);
+        if (PyErr_Occurred()) {
+            PyErr_Clear();
+            return ms_error_with_path("Number out of range%U", path);
+        }
+        return ms_decode_float(x, type, path);
     }
     else if (
         type->types & MS_TYPE_DECIMAL

--- a/tests/unit/test_convert.py
+++ b/tests/unit/test_convert.py
@@ -429,6 +429,11 @@ class TestFloat:
         with pytest.raises(ValidationError, match="Expected `float`, got `null`"):
             convert(None, float)
 
+    @pytest.mark.parametrize("val", [10**400, -10**400])
+    def test_float_from_int_out_of_range(self, val):
+        with pytest.raises(ValidationError, match="Number out of range"):
+            convert(val, float)
+
     @pytest.mark.parametrize(
         "meta, good, bad",
         [


### PR DESCRIPTION
## Summary
- Fix `msgspec.convert(large_int, float)` leaking `SystemError` when `PyLong_AsDouble` overflows
- Raise `ValidationError: Number out of range` instead, matching `json.decode` behavior

Fixes #1122

## Root cause
In `convert_int()`, when the target type is `float`, the code called `PyLong_AsDouble()` and passed the result directly to `ms_decode_float()` without checking for overflow. CPython sets `OverflowError: int too large to convert to float` but still returns a `double`, so the C function returned a valid float while an exception was set — Python then raised `SystemError`.

The JSON decode path already handles this correctly via `ms_hpd_to_double()` + `Py_IS_INFINITY` check → `ms_error_with_path("Number out of range%U", path)`.

## Test plan
- [x] Added regression test for `convert(10**400, float)` and negative variant
- [x] Full unit test suite passes locally (`6052 passed`, 473 skipped)