### PR TITLE
Fix unquoted Struct forward references on Python 3.14

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -30,6 +30,8 @@
 - Fix the `msgspec.json.decode` docstring to say `dec_hook` should raise
   `NotImplementedError` for unsupported types, not `TypeError` ({issue}`774`).
 - Fix backing type declaration of `Ext.code` ({pr}`1135`).
+- Fix `NameError` when creating a `Struct` with an unquoted forward
+  reference on Python 3.14 ({issue}`1165`).
 - msgspec moved to the [msgspec GitHub organization](https://github.com/msgspec/msgspec);
   documentation now lives at [msgspec.dev](https://msgspec.dev) (repository
   references updated in {pr}`1045`).

--- a/src/msgspec/_core.c
+++ b/src/msgspec/_core.c
@@ -6120,7 +6120,12 @@ structmeta_collect_fields(StructMetaInfo *info, MsgspecState *mod, bool kwonly) 
             Py_DECREF(annotate);
             return 0;
         }
-        PyObject *format = PyLong_FromLong(1);  /* annotationlib.Format.VALUE */
+        /* Format.FORWARDREF (3) rather than Format.VALUE (1): unresolved
+         * names must not raise NameError while the class body is still
+         * executing. See PEP 649 / annotationlib metaclass guidance:
+         * https://docs.python.org/3/library/annotationlib.html#using-annotations-in-a-metaclass
+         */
+        PyObject *format = PyLong_FromLong(3);  /* annotationlib.Format.FORWARDREF */
         if (format == NULL) {
             Py_DECREF(annotate);
             return -1;

--- a/src/msgspec/_core.c
+++ b/src/msgspec/_core.c
@@ -530,6 +530,7 @@ typedef struct {
     PyObject *concrete_types;
     PyObject *get_type_hints;
     PyObject *get_class_annotations;
+    PyObject *call_annotate_forwardref;
     PyObject *get_typeddict_info;
     PyObject *get_dataclass_info;
     PyObject *convert_generic_alias;
@@ -6120,21 +6121,12 @@ structmeta_collect_fields(StructMetaInfo *info, MsgspecState *mod, bool kwonly) 
             Py_DECREF(annotate);
             return 0;
         }
-        /* Format.FORWARDREF (3) rather than Format.VALUE (1): unresolved
-         * names must not raise NameError while the class body is still
-         * executing. See PEP 649 / annotationlib metaclass guidance:
+        /* Use Format.FORWARDREF so unresolved names do not raise NameError
+         * while the class body is still executing. See PEP 649 / annotationlib:
          * https://docs.python.org/3/library/annotationlib.html#using-annotations-in-a-metaclass
          */
-        PyObject *format = PyLong_FromLong(3);  /* annotationlib.Format.FORWARDREF */
-        if (format == NULL) {
-            Py_DECREF(annotate);
-            return -1;
-        }
-        annotations = PyObject_CallOneArg(
-            annotate, format
-        );
+        annotations = PyObject_CallOneArg(mod->call_annotate_forwardref, annotate);
         Py_DECREF(annotate);
-        Py_DECREF(format);
         if (annotations == NULL) {
             return -1;
         }
@@ -22700,6 +22692,7 @@ msgspec_clear(PyObject *m)
     Py_CLEAR(st->concrete_types);
     Py_CLEAR(st->get_type_hints);
     Py_CLEAR(st->get_class_annotations);
+    Py_CLEAR(st->call_annotate_forwardref);
     Py_CLEAR(st->get_typeddict_info);
     Py_CLEAR(st->get_dataclass_info);
     Py_CLEAR(st->rebuild);
@@ -22774,6 +22767,7 @@ msgspec_traverse(PyObject *m, visitproc visit, void *arg)
     Py_VISIT(st->concrete_types);
     Py_VISIT(st->get_type_hints);
     Py_VISIT(st->get_class_annotations);
+    Py_VISIT(st->call_annotate_forwardref);
     Py_VISIT(st->get_typeddict_info);
     Py_VISIT(st->get_dataclass_info);
     Py_VISIT(st->rebuild);
@@ -22976,6 +22970,7 @@ PyInit__core(void)
     SET_REF(concrete_types, "_CONCRETE_TYPES");
     SET_REF(get_type_hints, "get_type_hints");
     SET_REF(get_class_annotations, "get_class_annotations");
+    SET_REF(call_annotate_forwardref, "call_annotate_forwardref");
     SET_REF(get_typeddict_info, "get_typeddict_info");
     SET_REF(get_dataclass_info, "get_dataclass_info");
     SET_REF(typing_annotated_alias, "_AnnotatedAlias");

--- a/src/msgspec/_utils.py
+++ b/src/msgspec/_utils.py
@@ -53,11 +53,26 @@ else:
 
 
 if sys.version_info >= (3, 14):
+    from annotationlib import Format as _AnnotationFormat
+    from annotationlib import call_annotate_function as _call_annotate_function
     from annotationlib import get_annotations as _get_class_annotations
+
+    def call_annotate_forwardref(annotate):
+        """Evaluate a class annotate function without requiring names to exist.
+
+        Metaclasses should use ``Format.FORWARDREF`` (via
+        ``call_annotate_function``, which implements the format when the
+        annotate function only supports ``VALUE``).
+        """
+        return _call_annotate_function(annotate, _AnnotationFormat.FORWARDREF)
+
 else:
 
     def _get_class_annotations(cls):
         return cls.__dict__.get("__annotations__", {})
+
+    def call_annotate_forwardref(annotate):
+        return annotate(1)  # annotationlib.Format.VALUE
 
 
 def _apply_params(obj, mapping):

--- a/src/msgspec/_utils.py
+++ b/src/msgspec/_utils.py
@@ -53,9 +53,11 @@ else:
 
 
 if sys.version_info >= (3, 14):
-    from annotationlib import Format as _AnnotationFormat
-    from annotationlib import call_annotate_function as _call_annotate_function
-    from annotationlib import get_annotations as _get_class_annotations
+    from annotationlib import (
+        Format as _AnnotationFormat,
+        call_annotate_function as _call_annotate_function,
+        get_annotations as _get_class_annotations,
+    )
 
     def call_annotate_forwardref(annotate):
         """Evaluate a class annotate function without requiring names to exist.

--- a/tests/unit/test_struct.py
+++ b/tests/unit/test_struct.py
@@ -2700,3 +2700,96 @@ class TestPostInit:
         x2 = x1.__copy__()
         assert x1 == x2
         assert count == 1
+
+
+class TestForwardReferences:
+    """Quoted forward refs work on all supported Pythons. Unquoted forward
+    refs are only valid under PEP 649 deferred annotations (3.14+).
+    """
+
+    def test_quoted_forward_reference_struct_fields(self):
+        source = """
+        import msgspec
+
+        class Outer(msgspec.Struct):
+            inner: "Inner"
+
+        class Inner(msgspec.Struct):
+            value: int
+        """
+        with temp_module(source) as mod:
+            assert mod.Outer.__struct_fields__ == ("inner",)
+            msg = mod.Outer(mod.Inner(1))
+            assert msgspec.json.decode(msgspec.json.encode(msg), type=mod.Outer) == msg
+
+    def test_future_annotations_forward_reference_struct_fields(self):
+        source = """
+        from __future__ import annotations
+        import msgspec
+
+        class Outer(msgspec.Struct):
+            inner: Inner
+
+        class Inner(msgspec.Struct):
+            value: int
+        """
+        with temp_module(source) as mod:
+            assert mod.Outer.__struct_fields__ == ("inner",)
+            msg = mod.Outer(mod.Inner(1))
+            assert msgspec.json.decode(msgspec.json.encode(msg), type=mod.Outer) == msg
+
+    @pytest.mark.skipif(
+        sys.version_info < (3, 14),
+        reason="unquoted forward references require PEP 649 (Python 3.14+)",
+    )
+    def test_unquoted_forward_reference_struct_fields(self):
+        source = """
+        import msgspec
+
+        class Outer(msgspec.Struct):
+            inner: Inner
+
+        class Inner(msgspec.Struct):
+            value: int
+        """
+        with temp_module(source) as mod:
+            assert mod.Outer.__struct_fields__ == ("inner",)
+            assert mod.Outer.__annotations__["inner"] is mod.Inner
+            msg = mod.Outer(mod.Inner(1))
+            assert msgspec.json.decode(msgspec.json.encode(msg), type=mod.Outer) == msg
+
+    @pytest.mark.skipif(
+        sys.version_info < (3, 14),
+        reason="unquoted forward references require PEP 649 (Python 3.14+)",
+    )
+    def test_unquoted_forward_reference_generic_container(self):
+        source = """
+        import msgspec
+
+        class Outer(msgspec.Struct):
+            items: list[Inner]
+
+        class Inner(msgspec.Struct):
+            value: int
+        """
+        with temp_module(source) as mod:
+            assert mod.Outer.__struct_fields__ == ("items",)
+            msg = mod.Outer([mod.Inner(1), mod.Inner(2)])
+            assert msgspec.json.decode(msgspec.json.encode(msg), type=mod.Outer) == msg
+
+    @pytest.mark.skipif(
+        sys.version_info < (3, 14),
+        reason="unquoted forward references require PEP 649 (Python 3.14+)",
+    )
+    def test_unquoted_mutual_forward_references(self):
+        source = """
+        import msgspec
+
+        class Node(msgspec.Struct):
+            value: int
+            child: Node | None = None
+        """
+        with temp_module(source) as mod:
+            assert mod.Node.__struct_fields__ == ("value", "child")
+            msg = mod.Node(1, mod.Node(2))
+            assert msgspec.json.decode(msgspec.json.encode(msg), type=mod.Node) == msg


### PR DESCRIPTION
Fixes #1165.

On Python 3.14, Struct field collection invoked the class __annotate__ function with annotationlib.Format.VALUE. That evaluates annotations immediately, so an unquoted forward reference raises NameError while the class is still being created. Ordinary 3.14 classes do not do this.

This change evaluates annotations through annotationlib.call_annotate_function(..., Format.FORWARDREF), matching the annotationlib metaclass guidance. Compiler-generated annotate functions often raise NotImplementedError if FORWARDREF is passed directly; call_annotate_function implements that format.

Field names (and ClassVar detection) still run at class creation time; types continue to resolve later through the existing delayed annotation path.

Quoted annotations and from __future__ import annotations are unchanged. Older Python versions are unaffected because they never take the __annotate__ path.

Tests cover quoted forward refs, future-annotations forward refs, unquoted forward refs and self-recursive structs on 3.14+, JSON encode/decode after both types are defined, and existing ClassVar cases on 3.14.