### PR TITLE
Add missing 0.22.0 changelog entries

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -18,11 +18,18 @@
   `ms_decode_bigint`, and `Encoder.__init__` ({pr}`1021`, {pr}`1022`,
   {pr}`1023`, {pr}`1040`).
 - Fix `msgspec.inspect.type_info` and `msgspec.json.schema` crashing on mixed-type `Literal`s such as `Literal[1, None]` ({pr}`1080`).
+- Place `null` last in the `anyOf` generated for optional unions in JSON
+  schemas ({pr}`1028`).
+- Fix `msgspec.json.encode` raising `TypeError` for a `dict` keyed by a plain
+  `enum.Enum` with `str` values ({pr}`1118`).
 - Fix missing GC traversal and clearing of some module state members ({pr}`1060`).
 - Ensure an exception is always set on allocation failures ({pr}`1044`).
 - Fix compilation warnings on Python 3.15 ({pr}`1077`).
+- Add overloads to the `Meta` type stub, so type checkers reject mixing `gt`
+  with `ge` or `lt` with `le` ({pr}`700`).
 - Many type stub improvements and fixes ({pr}`1014`, {pr}`1043`, {pr}`1053`,
-  {pr}`1055`, {pr}`1057`, {pr}`1062`, {pr}`1065`, {pr}`1074`, {pr}`1093`).
+  {pr}`1055`, {pr}`1057`, {pr}`1062`, {pr}`1065`, {pr}`1074`, {pr}`1093`,
+  {pr}`1114`).
 - Document the differences between `msgspec.structs.asdict`/`astuple` and
   `msgspec.to_builtins` ({pr}`1025`).
 - Document that `omit_defaults` ignores fields with a custom


### PR DESCRIPTION
The 0.21.1 to 0.22.0 changelog batch (#1112) landed on 2026-07-03. Four user-visible changes merged between then and the 0.22.0 release on 2026-08-11 never got an entry:

- #700, overloads on the `Meta` stub, so type checkers reject mixing `gt` with `ge` and `lt` with `le`
- #1028, `null` placed last in the `anyOf` generated for optional unions
- #1114, `__struct_encode_fields__` added to `src/msgspec/__init__.pyi` (its companion #813 only touched `tests/typing`, so it needs no entry of its own)
- #1118, `json.encode` raising `TypeError` for a `dict` keyed by a plain `str`-valued `enum.Enum`

I went over every PR merged in that window. The rest need no entry: #813 and #1117 are tests only, #1121 fixes an unreleased regression from #1028, #1145 is an unused variable under free-threaded builds, and #1146 and #1148 are CI and tooling. #1127, #1135 and #1080 already have entries.

Docs build clean with `--fail-on-warning`.

Note for whoever retries the release: the section is still headed `Version 0.22.0 (2026-08-11)`, and that date will need updating, since the tag was deleted after the upload failed. Refs #1134.