### PR TITLE
Declare Struct instance defaults in the type stub

### DIFF
--- a/src/msgspec/__init__.pyi
+++ b/src/msgspec/__init__.pyi
@@ -96,6 +96,7 @@ def field(*, name: str | None = None) -> Any: ...
 @dataclass_transform(field_specifiers=(field,))
 class Struct(metaclass=StructMeta):
     __struct_fields__: ClassVar[tuple[str, ...]]
+    __struct_defaults__: ClassVar[tuple[Any, ...]]
     __struct_config__: ClassVar[structs.StructConfig]
     __struct_encode_fields__: ClassVar[tuple[str, ...]]
     __match_args__: ClassVar[tuple[str, ...]]

--- a/tests/typing/basic_typing_examples.py
+++ b/tests/typing/basic_typing_examples.py
@@ -344,6 +344,7 @@ def check_struct_attributes() -> None:
         y: int
 
     assert_type(Point.__struct_fields__, tuple[str, ...])
+    assert_type(Point.__struct_defaults__, tuple[Any, ...])
 
     for field in Point.__match_args__:
         # mypy inferences `field` as `str`,
@@ -354,6 +355,7 @@ def check_struct_attributes() -> None:
 
     assert_type(p.__struct_fields__, tuple[str, ...])
     assert_type(p.__struct_encode_fields__, tuple[str, ...])
+    assert_type(p.__struct_defaults__, tuple[Any, ...])
 
 
 def check_struct_config() -> None:


### PR DESCRIPTION
`__struct_defaults__` is available on both Struct classes and instances, but only the metaclass stub declares it. Access through an instance therefore fails type checking even though it works at runtime.

Add the missing Struct annotation and cover class and instance access in the existing typing examples. Runtime behavior is unchanged.

Fixes #779.

Validation: the new instance assertion fails with mypy, pyright, and pyrefly before the change; all three typing suites and stubtest pass afterward. On CPython 3.12, all 6,412 unit tests and 7 package doctests pass, with 118 skips; the repository's lint, format, and spelling checks pass. Windows validation used UTF-8 mode for the existing C-source text checks and a private LLVM-MinGW compiler adapter to build the unchanged extension. Neither is included in this patch.

Implemented and independently reviewed by automated agents before submission.
