### PR TITLE
Build the full wheel matrix weekly, not only at release

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,6 +35,10 @@ on:
   release:
     types:
     - published
+  schedule:
+    # Weekly full wheel build (build-all), so a musllinux or riscv64 breakage
+    # surfaces before the release run that would otherwise be the first to try it.
+    - cron: '17 4 * * 1'
 
 permissions: {}
 
@@ -201,7 +205,7 @@ jobs:
       contents: read
     with:
       sdist-name: "${{ needs.prepare.outputs.sdist-name }}"
-      build-all: ${{ github.event_name == 'release' }}
+      build-all: ${{ github.event_name == 'release' || github.event_name == 'schedule' }}
 
   upload-pypi:
     name: Upload artifacts to PyPI


### PR DESCRIPTION
`build-wheels.yml` skips every musllinux wheel unless `build-all` is true, and `ci.yml` only passes `build-all` on release. So no musllinux wheel, on any architecture, is built outside a release, and the first run that can show a musllinux breakage is the one meant to publish. #1134 hit exactly that when `cp310-musllinux_riscv64` failed on the 0.22.0 release build, and #1146 could not be exercised by its own CI for the same reason.

**Change.** `ci.yml` gains a weekly `schedule` trigger (Monday 04:17 UTC) and passes `build-all` on `schedule` as well as on `release`, so the complete matrix, musllinux and riscv64 included, runs on a timer between releases. Pull request and push runs are unchanged, and so is the `build-riscv64` label gate. Five lines, no new jobs.

**What proves it.** A workflow cannot run locally; the file parses as YAML. The first scheduled run showing the musllinux and riscv64 legs outside a release is the proof. If PR-time coverage is wanted as well, a single `cp312-musllinux_x86_64` smoke build gated on changes to the wheel workflow, `setup.py`, `pyproject.toml` or `src/` is a small follow-up; I left it out of this change so the schedule can land on its own.

One question for the reviewer: is weekly the right cadence for the project's CI budget, or would you rather tie the full build to a pre-release tag?

Closes #1150
