### PR TITLE
Fix empty Raw type names in validation errors

### DIFF
--- a/src/msgspec/_core.c
+++ b/src/msgspec/_core.c
@@ -3493,12 +3493,8 @@ typenode_simple_repr(TypeNode *self) {
     if (self->types & (MS_TYPE_ANY | MS_TYPE_CUSTOM | MS_TYPE_CUSTOM_GENERIC)) {
         return PyUnicode_FromString("any");
     }
-    if (self->types == 0) {
-        /* `Raw` is marked with a typecode of 0. JSON/msgpack decoding never
-         * reaches this repr for a `Raw` field (the raw bytes are captured
-         * before type checking), but `convert()` has no such interception
-         * and falls through to here on a type mismatch -- report `raw`, not
-         * `any`, so the message doesn't contradict the error being raised. */
+    if ((self->types & ~MS_EXTRA_FLAG) == 0) {
+        /* Ignore TypedDict/dataclass field metadata when identifying Raw. */
         return PyUnicode_FromString("raw");
     }
     if (self->types & (MS_TYPE_BOOL | MS_TYPE_BOOLLITERAL_TRUE | MS_TYPE_BOOLLITERAL_FALSE)) {

--- a/tests/unit/test_convert.py
+++ b/tests/unit/test_convert.py
@@ -2796,3 +2796,26 @@ class TestRaw:
 
         with pytest.raises(ValidationError, match=r"^Expected `raw`, got `\w+`"):
             convert({"x": value}, type=Ex)
+
+    @pytest.mark.parametrize("total", [False, True])
+    @pytest.mark.parametrize("value, kind", [(None, "null"), (1, "int")])
+    def test_raw_typeddict_error_message(self, total, value, kind):
+        class Ex(TypedDict, total=total):
+            x: msgspec.Raw
+
+        with pytest.raises(ValidationError) as rec:
+            convert({"x": value}, type=Ex)
+        assert str(rec.value) == f"Expected `raw`, got `{kind}` - at `$.x`"
+
+    @pytest.mark.parametrize("default_factory", [False, True])
+    @pytest.mark.parametrize("value, kind", [(None, "null"), (1, "int")])
+    def test_raw_dataclass_error_message(self, default_factory, value, kind):
+        @dataclass
+        class Ex:
+            x: msgspec.Raw = (
+                field(default_factory=msgspec.Raw) if default_factory else field()
+            )
+
+        with pytest.raises(ValidationError) as rec:
+            convert({"x": value}, type=Ex)
+        assert str(rec.value) == f"Expected `raw`, got `{kind}` - at `$.x`"


### PR DESCRIPTION
Invalid input for required `Raw` fields in a `TypedDict`, or `Raw` fields with a dataclass default factory, could produce an empty expected-type name in validation errors. Ignore field metadata when formatting the type name so these errors include `raw`.

Follow-up to #1169.
